### PR TITLE
Modified callback functions to enable return of error code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ The optimization process is initiated by calling a solver function. This functio
   - The objective function value
   - The gradient
   - The Hessian diagonal
-  - A `hess_x` function that performs a Hessian linear transformation for a trial function
+  - A `hess_x` function that performs a Hessian linear transformation for a trial function, also returns a logical which indicates whether the function has encountered an error
+  - A logical which indicates whether the function has encountered an error
 - **`obj_func`** (function): Accepts the variable change and returns the objective function value.
 - **`n_param`** (integer): Specifies the number of parameters to be optimized.
 - **`error`** (boolean): Returns whether the solver has produced an error.
@@ -52,8 +53,8 @@ The optimization process is initiated by calling a solver function. This functio
 ### Optional Arguments
 The optimization process can be fine-tuned using the following optional arguments:
 
-- **`precond`** (function): Accepts a vector and a level shift and outputs a preconditioned vector.
-- **`conv_check`** (function): Returns whether the optimization has converged due to some supplied convergence criterion.
+- **`precond`** (function): Accepts a vector and a level shift and outputs a preconditioned vector and a logical which indicates whether the function has encountered an error.
+- **`conv_check`** (function): Returns whether the optimization has converged due to some supplied convergence criterion and a logical which indicates whether the function has encountered an error.
 - **`stability`** (boolean): Determines whether a stability check is performed upon convergence.
 - **`line_search`** (boolean): Determines whether a line search is performed after every macro iteration.
 - **`davidson`** (boolean): Determines whether level-shifted augmented Hessian with Davidson or truncated conjugate gradient is utilized to solve the trust-region subsystem.
@@ -76,13 +77,13 @@ A separate `stability_check` function is available to verify whether the current
 ### Required Arguments
 
 - **`h_diag`** (real array): Represents the Hessian diagonal at the current point.
-- **`hess_x`** (function): Performs a Hessian linear transformation of a trial vector at the current point.
+- **`hess_x`** (function): Performs a Hessian linear transformation of a trial vector at the current point, also returns a logical which indicates whether the function has encountered an error.
 - **`stable`** (boolean): Returns whether the current point is stable.
 - **`kappa`** (boolean): Returns descent direction if current point is not stable
 
 ### Optional Arguments
 
-- **`precond`** (function): Accepts a vector and a level shift and outputs a preconditioned vector.
+- **`precond`** (function): Accepts a vector and a level shift and outputs a preconditioned vector and a logical which indicates whether the function has encountered an error.
 - **`jacobi_davidson`** (boolean): Determines whether Jacobi-Davidson is performed whenever difficult convergence is encountered for Davidson iterations.
 - **`conv_tol`** (real): Convergence criterion for the residual norm.
 - **`n_random_trial_vectors`** (integer): Number of random trial vectors used to start the Davidson iterations.

--- a/README.md
+++ b/README.md
@@ -44,17 +44,17 @@ The optimization process is initiated by calling a solver function. This functio
   - The objective function value
   - The gradient
   - The Hessian diagonal
-  - A `hess_x` function that performs a Hessian linear transformation for a trial function, also returns a logical which indicates whether the function has encountered an error
-  - A logical which indicates whether the function has encountered an error
+  - A `hess_x` function that performs a Hessian linear transformation for a trial function, also returns an integer which indicates whether the function has encountered an error
+  - An integer which indicates whether the function has encountered an error
 - **`obj_func`** (function): Accepts the variable change and returns the objective function value.
 - **`n_param`** (integer): Specifies the number of parameters to be optimized.
-- **`error`** (boolean): Returns whether the solver has produced an error.
+- **`error`** (integer): Returns whether the solver has produced an error.
 
 ### Optional Arguments
 The optimization process can be fine-tuned using the following optional arguments:
 
-- **`precond`** (function): Accepts a vector and a level shift and outputs a preconditioned vector and a logical which indicates whether the function has encountered an error.
-- **`conv_check`** (function): Returns whether the optimization has converged due to some supplied convergence criterion and a logical which indicates whether the function has encountered an error.
+- **`precond`** (function): Accepts a vector and a level shift and outputs a preconditioned vector and an integer which indicates whether the function has encountered an error.
+- **`conv_check`** (function): Returns whether the optimization has converged due to some supplied convergence criterion and an integer which indicates whether the function has encountered an error.
 - **`stability`** (boolean): Determines whether a stability check is performed upon convergence.
 - **`line_search`** (boolean): Determines whether a line search is performed after every macro iteration.
 - **`davidson`** (boolean): Determines whether level-shifted augmented Hessian with Davidson or truncated conjugate gradient is utilized to solve the trust-region subsystem.
@@ -77,13 +77,13 @@ A separate `stability_check` function is available to verify whether the current
 ### Required Arguments
 
 - **`h_diag`** (real array): Represents the Hessian diagonal at the current point.
-- **`hess_x`** (function): Performs a Hessian linear transformation of a trial vector at the current point, also returns a logical which indicates whether the function has encountered an error.
+- **`hess_x`** (function): Performs a Hessian linear transformation of a trial vector at the current point, also returns an integer which indicates whether the function has encountered an error.
 - **`stable`** (boolean): Returns whether the current point is stable.
 - **`kappa`** (boolean): Returns descent direction if current point is not stable
 
 ### Optional Arguments
 
-- **`precond`** (function): Accepts a vector and a level shift and outputs a preconditioned vector and a logical which indicates whether the function has encountered an error.
+- **`precond`** (function): Accepts a vector and a level shift and outputs a preconditioned vector and an integer which indicates whether the function has encountered an error.
 - **`jacobi_davidson`** (boolean): Determines whether Jacobi-Davidson is performed whenever difficult convergence is encountered for Davidson iterations.
 - **`conv_tol`** (real): Convergence criterion for the residual norm.
 - **`n_random_trial_vectors`** (integer): Number of random trial vectors used to start the Davidson iterations.

--- a/README.md
+++ b/README.md
@@ -44,17 +44,17 @@ The optimization process is initiated by calling a solver function. This functio
   - The objective function value
   - The gradient
   - The Hessian diagonal
-  - A `hess_x` function that performs a Hessian linear transformation for a trial function, also returns an integer which indicates whether the function has encountered an error
-  - An integer which indicates whether the function has encountered an error
-- **`obj_func`** (function): Accepts the variable change and returns the objective function value.
+  - A `hess_x` function that performs a Hessian linear transformation for a trial function. Additionally, outputs an integer code indicating the success or failure of the function, positive integers less than 100 represent error conditions.
+  - An integer code indicating the success or failure of the function, positive integers less than 100 represent error conditions.
+- **`obj_func`** (function): Accepts the variable change and returns the objective function value. Additionally, outputs an integer code indicating the success or failure of the function, positive integers less than 100 represent error conditions.
 - **`n_param`** (integer): Specifies the number of parameters to be optimized.
-- **`error`** (integer): Returns whether the solver has produced an error.
+- **`error`** (integer): An integer code indicating the success or failure of the solver. The error code structure is explained below.
 
 ### Optional Arguments
 The optimization process can be fine-tuned using the following optional arguments:
 
-- **`precond`** (function): Accepts a vector and a level shift and outputs a preconditioned vector and an integer which indicates whether the function has encountered an error.
-- **`conv_check`** (function): Returns whether the optimization has converged due to some supplied convergence criterion and an integer which indicates whether the function has encountered an error.
+- **`precond`** (function): Accepts a vector and a level shift and outputs a preconditioned vector. Additionally, outputs an integer code indicating the success or failure of the function, positive integers less than 100 represent error conditions.
+- **`conv_check`** (function): Returns whether the optimization has converged due to some supplied convergence criterion. Additionally, outputs an integer code indicating the success or failure of the function, positive integers less than 100 represent error conditions.
 - **`stability`** (boolean): Determines whether a stability check is performed upon convergence.
 - **`line_search`** (boolean): Determines whether a line search is performed after every macro iteration.
 - **`davidson`** (boolean): Determines whether level-shifted augmented Hessian with Davidson or truncated conjugate gradient is utilized to solve the trust-region subsystem.
@@ -77,13 +77,14 @@ A separate `stability_check` function is available to verify whether the current
 ### Required Arguments
 
 - **`h_diag`** (real array): Represents the Hessian diagonal at the current point.
-- **`hess_x`** (function): Performs a Hessian linear transformation of a trial vector at the current point, also returns an integer which indicates whether the function has encountered an error.
+- **`hess_x`** (function): Performs a Hessian linear transformation of a trial vector at the current point. Additionally, outputs an integer code indicating the success or failure of the function, positive integers less than 100 represent error conditions.
 - **`stable`** (boolean): Returns whether the current point is stable.
-- **`kappa`** (boolean): Returns descent direction if current point is not stable
+- **`kappa`** (boolean): Returns descent direction if current point is not stable.
+- **`error`** (integer): An integer code indicating the success or failure of the solver. The error code structure is explained below.
 
 ### Optional Arguments
 
-- **`precond`** (function): Accepts a vector and a level shift and outputs a preconditioned vector and an integer which indicates whether the function has encountered an error.
+- **`precond`** (function): Accepts a vector and a level shift and outputs a preconditioned vector. Additionally, outputs an integer code indicating the success or failure of the function, positive integers less than 100 represent error conditions.
 - **`jacobi_davidson`** (boolean): Determines whether Jacobi-Davidson is performed whenever difficult convergence is encountered for Davidson iterations.
 - **`conv_tol`** (real): Convergence criterion for the residual norm.
 - **`n_random_trial_vectors`** (integer): Number of random trial vectors used to start the Davidson iterations.
@@ -94,7 +95,43 @@ A separate `stability_check` function is available to verify whether the current
 ---
 Both the solver and stability check functions can be directly accessed from Fortran, C, or Python using the same arguments but within the appropriate language.
 
-### Program Interfaces
+## Error Code Structure
+
+The library uses structured integer return codes to indicate whether a function has encountered an error. These codes follow the format **`OOEE`**, where:
+
+- **`OO`** = Origin of the error (which component/function reported the error)
+- **`EE`** = Specific error code
+
+### General Rules
+
+- A return code of `0` means success.
+- Return codes between `1` and `99` are currently unused.
+- All current error codes start from `100` and follow the `OOEE` structure.
+
+### Origins (`OO`)
+
+| Code Prefix (`OO`) | Component           |
+|--------------------|---------------------|
+| `01`               | `solver`            |
+| `02`               | `stability_check`   |
+| `11`               | `obj_func`          |
+| `12`               | `update_orbs`       |
+| `13`               | `hess_x`            |
+| `14`               | `precond`           |
+| `15`               | `conv_check`        |
+
+### Error Codes (`EE`)
+
+The error field (`EE`) is currently always set to `01`. Future versions may define more specific codes for different failure modes.
+
+### Example Error Codes
+
+| Error Code | Meaning                |
+|------------|------------------------|
+| `0101`     | Error in `solver`      |
+| `1201`     | Error in `update_orbs` |
+
+## Program Interfaces
 
 The PySCF interface is available as an extension hosted at https://github.com/eriksen-lab/pyscf_opentrustregion. To install it, simply add its path to the **`PYSCF_EXT_PATH`** environment variable:
 ```sh

--- a/include/opentrustregion.h
+++ b/include/opentrustregion.h
@@ -8,13 +8,12 @@
 extern "C" {
 #endif
 
-void solver(
-    const void (*update_orbs)(const double*, double*, double**, double**, void (**)(const double*, double**)),
-    const double (*obj_func)(const double*),
+bool solver(
+    const bool (*update_orbs)(const double*, double*, double**, double**, bool (**)(const double*, double**)),
+    const bool (*obj_func)(const double*, double*),
     const int n_param,
-    const bool* error,
-    const void (*precond)(const double*, const double, double*),
-    const bool (*conv_check)(),
+    const bool (*precond)(const double*, const double, double**),
+    const bool (*conv_check)(bool*),
     const bool* stability_ptr,
     const bool* line_search_ptr,
     const bool* davidson_ptr,
@@ -32,14 +31,13 @@ void solver(
     const void (*logger)(const char*)
 );
 
-void stability_check(
+bool stability_check(
     const double* h_diag,
-    const void (*hess_x)(const double*, double**),
+    const bool (*hess_x)(const double*, double**),
     const int n_param,
     bool stable,
     double* kappa,
-    const bool* error,
-    const void (*precond_ptr)(const double*, const double, double*),
+    const bool (*precond)(const double*, const double, double**),
     const bool* jacobi_davidson_ptr,
     const double* conv_tol_ptr,
     const int* n_random_trial_vectors_ptr,

--- a/include/opentrustregion.h
+++ b/include/opentrustregion.h
@@ -9,11 +9,11 @@ extern "C" {
 #endif
 
 bool solver(
-    const bool (*update_orbs)(const double*, double*, double**, double**, bool (**)(const double*, double**)),
-    const bool (*obj_func)(const double*, double*),
+    const int (*update_orbs)(const double*, double*, double**, double**, int (**)(const double*, double**)),
+    const int (*obj_func)(const double*, double*),
     const int n_param,
-    const bool (*precond)(const double*, const double, double**),
-    const bool (*conv_check)(bool*),
+    const int (*precond)(const double*, const double, double**),
+    const int (*conv_check)(bool*),
     const bool* stability_ptr,
     const bool* line_search_ptr,
     const bool* davidson_ptr,
@@ -33,11 +33,11 @@ bool solver(
 
 bool stability_check(
     const double* h_diag,
-    const bool (*hess_x)(const double*, double**),
+    const int (*hess_x)(const double*, double**),
     const int n_param,
     bool stable,
     double* kappa,
-    const bool (*precond)(const double*, const double, double**),
+    const int (*precond)(const double*, const double, double**),
     const bool* jacobi_davidson_ptr,
     const double* conv_tol_ptr,
     const int* n_random_trial_vectors_ptr,

--- a/include/opentrustregion.h
+++ b/include/opentrustregion.h
@@ -4,45 +4,47 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-bool solver(
-    const int (*update_orbs)(const double*, double*, double**, double**, int (**)(const double*, double**)),
-    const int (*obj_func)(const double*, double*),
-    const int n_param,
-    const int (*precond)(const double*, const double, double**),
-    const int (*conv_check)(bool*),
+int64_t solver(
+    const int64_t (*update_orbs)(const double*, double*, double**, double**, int64_t (**)(const double*, double**)),
+    const int64_t (*obj_func)(const double*, double*),
+    const int64_t n_param,
+    const int64_t (*precond)(const double*, const double, double**),
+    const int64_t (*conv_check)(bool*),
     const bool* stability_ptr,
     const bool* line_search_ptr,
     const bool* davidson_ptr,
     const bool* jacobi_davidson_ptr,
     const bool* prefer_jacobi_davidson,
     const double* conv_tol_ptr,
-    const int* n_random_trial_vectors_ptr,
+    const int64_t* n_random_trial_vectors_ptr,
     const double* start_trust_radius_ptr,
-    const int* n_macro_ptr,
-    const int* n_micro_ptr,
+    const int64_t* n_macro_ptr,
+    const int64_t* n_micro_ptr,
     const bool* global_red_factor_ptr,
     const bool* local_red_factor_ptr,
-    const int* seed_ptr,
-    const int* verbose_ptr,
+    const int64_t* seed_ptr,
+    const int64_t* verbose_ptr,
     const void (*logger)(const char*)
 );
 
-bool stability_check(
+int64_t stability_check(
     const double* h_diag,
-    const int (*hess_x)(const double*, double**),
-    const int n_param,
+    const int64_t (*hess_x)(const double*, double**),
+    const int64_t n_param,
     bool stable,
     double* kappa,
-    const int (*precond)(const double*, const double, double**),
+    const int64_t (*precond)(const double*, const double, double**),
     const bool* jacobi_davidson_ptr,
     const double* conv_tol_ptr,
-    const int* n_random_trial_vectors_ptr,
-    const int* n_iter_ptr,
-    const int* verbose_ptr,
+    const int64_t* n_random_trial_vectors_ptr,
+    const int64_t* n_iter_ptr,
+    const int64_t* verbose_ptr,
     const void (*logger)(const char*)
 );
 

--- a/pyopentrustregion/__init__.py
+++ b/pyopentrustregion/__init__.py
@@ -4,7 +4,4 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from pyopentrustregion.python_interface import (
-    solver_py_interface,
-    stability_check_py_interface,
-)
+from pyopentrustregion.python_interface import solver, stability_check

--- a/pyopentrustregion/python_interface.py
+++ b/pyopentrustregion/python_interface.py
@@ -112,7 +112,7 @@ def solver(
         try:
             func_ptr[0], grad, h_diag, hess_x = update_orbs(kappa)
         except RuntimeError:
-            return True
+            return 1
 
         # convert numpy arrays to pointers
         grad_ptr[0] = grad.ctypes.data_as(POINTER(c_double))
@@ -131,17 +131,17 @@ def solver(
             try:
                 hx = hess_x(x)
             except RuntimeError:
-                return True
+                return 1
 
             # convert numpy array to pointer
             hx_ptr[0] = hx.ctypes.data_as(POINTER(c_double))
 
-            return False
+            return 0
 
         # store the function pointer in hess_x_ptr
         hess_x_funptr[0] = hess_x_interface
 
-        return False
+        return 0
 
     @obj_func_interface_type
     def obj_func_interface(kappa_ptr, func_ptr):
@@ -154,9 +154,9 @@ def solver(
         try:
             func_ptr[0] = obj_func(kappa)
         except RuntimeError:
-            return True
+            return 1
 
-        return False
+        return 0
 
     @precond_interface_type
     def precond_interface(residual_ptr, mu_ptr, precond_residual_ptr):
@@ -175,12 +175,12 @@ def solver(
         try:
             precond_residual = precond(residual, mu)
         except RuntimeError:
-            return True
+            return 1
 
         # convert numpy array to pointer
         precond_residual_ptr[0] = precond_residual.ctypes.data_as(POINTER(c_double))
 
-        return False
+        return 0
 
     @conv_check_interface_type
     def conv_check_interface(conv_ptr):
@@ -190,9 +190,9 @@ def solver(
         try:
             conv_ptr[0] = conv_check()
         except RuntimeError:
-            return True
+            return 1
 
-        return False
+        return 0
 
     @logger_interface_type
     def logger_interface(message):
@@ -298,12 +298,12 @@ def stability_check(
         try:
             hx = hess_x(x)
         except RuntimeError:
-            return True
+            return 1
 
         # convert numpy array to pointer
         hx_ptr[0] = hx.ctypes.data_as(POINTER(c_double))
 
-        return False
+        return 0
 
     @precond_interface_type
     def precond_interface(residual_ptr, mu_ptr, precond_residual_ptr):
@@ -319,12 +319,12 @@ def stability_check(
         try:
             precond_residual = precond(residual, mu)
         except RuntimeError:
-            return True
+            return 1
 
         # convert numpy array to pointer
         precond_residual_ptr[0] = precond_residual.ctypes.data_as(POINTER(c_double))
 
-        return False
+        return 0
 
     @logger_interface_type
     def logger_interface(message):

--- a/pyopentrustregion/python_interface.py
+++ b/pyopentrustregion/python_interface.py
@@ -45,7 +45,7 @@ except OSError:
         raise FileNotFoundError("Cannot find opentrustregion library.")
 
 
-def solver_py_interface(
+def solver(
     obj_func: Callable[[np.ndarray], float],
     update_orbs: Callable[
         [np.ndarray],
@@ -74,21 +74,21 @@ def solver_py_interface(
     # types so we interface to Fortran subroutines by creating pointers to the relevant
     # data
     hess_x_interface_type = CFUNCTYPE(
-        None, POINTER(c_double), POINTER(POINTER(c_double))
+        c_bool, POINTER(c_double), POINTER(POINTER(c_double))
     )
     update_orbs_interface_type = CFUNCTYPE(
-        None,
+        c_bool,
         POINTER(c_double),
         POINTER(c_double),
         POINTER(POINTER(c_double)),
         POINTER(POINTER(c_double)),
         POINTER(hess_x_interface_type),
     )
-    obj_func_interface_type = CFUNCTYPE(c_double, POINTER(c_double))
+    obj_func_interface_type = CFUNCTYPE(c_bool, POINTER(c_double), POINTER(c_double))
     precond_interface_type = CFUNCTYPE(
-        None, POINTER(c_double), POINTER(c_double), POINTER(POINTER(c_double))
+        c_bool, POINTER(c_double), POINTER(c_double), POINTER(POINTER(c_double))
     )
-    conv_check_interface_type = CFUNCTYPE(c_bool)
+    conv_check_interface_type = CFUNCTYPE(c_bool, POINTER(c_bool))
     logger_interface_type = CFUNCTYPE(None, c_char_p)
 
     @update_orbs_interface_type
@@ -109,7 +109,10 @@ def solver_py_interface(
 
         # update orbitals and retrieve objective function, gradient, Hessian diagonal
         # and Hessian linear transformation function
-        func_ptr[0], grad, h_diag, hess_x = update_orbs(kappa)
+        try:
+            func_ptr[0], grad, h_diag, hess_x = update_orbs(kappa)
+        except RuntimeError:
+            return True
 
         # convert numpy arrays to pointers
         grad_ptr[0] = grad.ctypes.data_as(POINTER(c_double))
@@ -125,23 +128,35 @@ def solver_py_interface(
             x = np.ctypeslib.as_array(x_ptr, shape=(n_param,))
 
             # perform linear transformation
-            hx = hess_x(x)
+            try:
+                hx = hess_x(x)
+            except RuntimeError:
+                return True
 
             # convert numpy array to pointer
             hx_ptr[0] = hx.ctypes.data_as(POINTER(c_double))
 
+            return False
+
         # store the function pointer in hess_x_ptr
         hess_x_funptr[0] = hess_x_interface
 
+        return False
+
     @obj_func_interface_type
-    def obj_func_interface(kappa_ptr):
+    def obj_func_interface(kappa_ptr, func_ptr):
         """
         this function returns the function value
         """
         # convert orbital rotation matrix pointer to numpy array
         kappa = np.ctypeslib.as_array(kappa_ptr, shape=(n_param,))
 
-        return obj_func(kappa)
+        try:
+            func_ptr[0] = obj_func(kappa)
+        except RuntimeError:
+            return True
+
+        return False
 
     @precond_interface_type
     def precond_interface(residual_ptr, mu_ptr, precond_residual_ptr):
@@ -157,17 +172,27 @@ def solver_py_interface(
         mu = mu_ptr[0]
 
         # get preconditioner
-        precond_residual = precond(residual, mu)
+        try:
+            precond_residual = precond(residual, mu)
+        except RuntimeError:
+            return True
 
         # convert numpy array to pointer
         precond_residual_ptr[0] = precond_residual.ctypes.data_as(POINTER(c_double))
 
+        return False
+
     @conv_check_interface_type
-    def conv_check_interface():
+    def conv_check_interface(conv_ptr):
         """
         this function performs a convergence check
         """
-        return conv_check()
+        try:
+            conv_ptr[0] = conv_check()
+        except RuntimeError:
+            return True
+
+        return False
 
     @logger_interface_type
     def logger_interface(message):
@@ -178,12 +203,11 @@ def solver_py_interface(
         logger(string_at(message).decode("utf-8"))
 
     # define result and argument types
-    libopentrustregion.solver.restype = None
+    libopentrustregion.solver.restype = c_bool
     libopentrustregion.solver.argtypes = [
         c_void_p,
         c_void_p,
         c_long,
-        POINTER(c_bool),
         c_void_p,
         c_void_p,
         POINTER(c_bool),
@@ -203,15 +227,11 @@ def solver_py_interface(
         c_void_p,
     ]
 
-    # initialize return variables
-    error = c_bool(False)
-
     # call Fortran function
-    libopentrustregion.solver(
+    error = libopentrustregion.solver(
         update_orbs_interface,
         obj_func_interface,
         n_param,
-        byref(error),
         None if precond is None else precond_interface,
         None if conv_check is None else conv_check_interface,
         None if stability is None else byref(c_bool(stability)),
@@ -243,7 +263,7 @@ def solver_py_interface(
         raise RuntimeError("OpenTrustRegion solver produced error.")
 
 
-def stability_check_py_interface(
+def stability_check(
     h_diag: np.ndarray,
     hess_x: Callable[[np.ndarray], np.ndarray],
     n_param: int,
@@ -258,10 +278,10 @@ def stability_check_py_interface(
     # callback function ctypes specifications, ctypes can only deal with simple return
     # types so we interface to Fortran subroutines by creating data to the relevant data
     hess_x_interface_type = CFUNCTYPE(
-        None, POINTER(c_double), POINTER(POINTER(c_double))
+        c_bool, POINTER(c_double), POINTER(POINTER(c_double))
     )
     precond_interface_type = CFUNCTYPE(
-        None, POINTER(c_double), POINTER(c_double), POINTER(POINTER(c_double))
+        c_bool, POINTER(c_double), POINTER(c_double), POINTER(POINTER(c_double))
     )
     logger_interface_type = CFUNCTYPE(None, c_char_p)
 
@@ -275,10 +295,15 @@ def stability_check_py_interface(
         x = np.ctypeslib.as_array(x_ptr, shape=(n_param,))
 
         # perform linear transformation
-        hx = hess_x(x)
+        try:
+            hx = hess_x(x)
+        except RuntimeError:
+            return True
 
         # convert numpy array to pointer
         hx_ptr[0] = hx.ctypes.data_as(POINTER(c_double))
+
+        return False
 
     @precond_interface_type
     def precond_interface(residual_ptr, mu_ptr, precond_residual_ptr):
@@ -291,10 +316,15 @@ def stability_check_py_interface(
         mu = mu_ptr[0]
 
         # perform linear transformation
-        precond_residual = precond(residual, mu)
+        try:
+            precond_residual = precond(residual, mu)
+        except RuntimeError:
+            return True
 
         # convert numpy array to pointer
         precond_residual_ptr[0] = precond_residual.ctypes.data_as(POINTER(c_double))
+
+        return False
 
     @logger_interface_type
     def logger_interface(message):
@@ -302,14 +332,13 @@ def stability_check_py_interface(
         logger(string_at(message).decode("utf-8"))
 
     # define result and argument types
-    libopentrustregion.stability_check.restype = None
+    libopentrustregion.stability_check.restype = c_bool
     libopentrustregion.stability_check.argtypes = [
         POINTER(c_double),
         c_void_p,
         c_long,
         POINTER(c_bool),
         POINTER(c_double),
-        POINTER(c_bool),
         c_void_p,
         POINTER(c_bool),
         POINTER(c_double),
@@ -322,16 +351,14 @@ def stability_check_py_interface(
     # initialize return variables
     stable = c_bool(False)
     kappa = np.empty(n_param, dtype=np.float64)
-    error = c_bool(False)
 
     # call Fortran function
-    libopentrustregion.stability_check(
+    error = libopentrustregion.stability_check(
         h_diag.ctypes.data_as(POINTER(c_double)),
         hess_x_interface,
         n_param,
         byref(stable),
         kappa.ctypes.data_as(POINTER(c_double)),
-        byref(error),
         None if precond is None else precond_interface,
         None if jacobi_davidson is None else byref(c_bool(jacobi_davidson)),
         None if conv_tol is None else byref(c_double(conv_tol)),

--- a/pyopentrustregion/python_interface.py
+++ b/pyopentrustregion/python_interface.py
@@ -74,21 +74,21 @@ def solver(
     # types so we interface to Fortran subroutines by creating pointers to the relevant
     # data
     hess_x_interface_type = CFUNCTYPE(
-        c_bool, POINTER(c_double), POINTER(POINTER(c_double))
+        c_long, POINTER(c_double), POINTER(POINTER(c_double))
     )
     update_orbs_interface_type = CFUNCTYPE(
-        c_bool,
+        c_long,
         POINTER(c_double),
         POINTER(c_double),
         POINTER(POINTER(c_double)),
         POINTER(POINTER(c_double)),
         POINTER(hess_x_interface_type),
     )
-    obj_func_interface_type = CFUNCTYPE(c_bool, POINTER(c_double), POINTER(c_double))
+    obj_func_interface_type = CFUNCTYPE(c_long, POINTER(c_double), POINTER(c_double))
     precond_interface_type = CFUNCTYPE(
-        c_bool, POINTER(c_double), POINTER(c_double), POINTER(POINTER(c_double))
+        c_long, POINTER(c_double), POINTER(c_double), POINTER(POINTER(c_double))
     )
-    conv_check_interface_type = CFUNCTYPE(c_bool, POINTER(c_bool))
+    conv_check_interface_type = CFUNCTYPE(c_long, POINTER(c_bool))
     logger_interface_type = CFUNCTYPE(None, c_char_p)
 
     @update_orbs_interface_type
@@ -203,7 +203,7 @@ def solver(
         logger(string_at(message).decode("utf-8"))
 
     # define result and argument types
-    libopentrustregion.solver.restype = c_bool
+    libopentrustregion.solver.restype = c_long
     libopentrustregion.solver.argtypes = [
         c_void_p,
         c_void_p,
@@ -278,10 +278,10 @@ def stability_check(
     # callback function ctypes specifications, ctypes can only deal with simple return
     # types so we interface to Fortran subroutines by creating data to the relevant data
     hess_x_interface_type = CFUNCTYPE(
-        c_bool, POINTER(c_double), POINTER(POINTER(c_double))
+        c_long, POINTER(c_double), POINTER(POINTER(c_double))
     )
     precond_interface_type = CFUNCTYPE(
-        c_bool, POINTER(c_double), POINTER(c_double), POINTER(POINTER(c_double))
+        c_long, POINTER(c_double), POINTER(c_double), POINTER(POINTER(c_double))
     )
     logger_interface_type = CFUNCTYPE(None, c_char_p)
 
@@ -332,7 +332,7 @@ def stability_check(
         logger(string_at(message).decode("utf-8"))
 
     # define result and argument types
-    libopentrustregion.stability_check.restype = c_bool
+    libopentrustregion.stability_check.restype = c_long
     libopentrustregion.stability_check.argtypes = [
         POINTER(c_double),
         c_void_p,

--- a/pyopentrustregion/testsuite.py
+++ b/pyopentrustregion/testsuite.py
@@ -44,6 +44,7 @@ except OSError:
 # define all tests
 fortran_tests = {
     "opentrustregion_tests": [
+        "add_error_origin",
         "truncated_conjugate_gradient",
         "level_shifted_davidson",
         "sanity_check",

--- a/pyopentrustregion/testsuite.py
+++ b/pyopentrustregion/testsuite.py
@@ -21,9 +21,9 @@ except ImportError:
 
 # check if pyopentrustregion is installed or import module in same directory
 try:
-    from pyopentrustregion import solver_py_interface, stability_check_py_interface
+    from pyopentrustregion import solver, stability_check
 except ImportError:
-    from python_interface import solver_py_interface, stability_check_py_interface
+    from python_interface import solver, stability_check
 
 # load the testsuite library
 ext = "dylib" if sys.platform == "darwin" else "so"
@@ -207,13 +207,13 @@ class PyInterfaceTests(unittest.TestCase):
             return
 
         # call solver python interface without optional arguments
-        solver_py_interface(mock_obj_func, mock_update_orbs, 3)
+        solver(mock_obj_func, mock_update_orbs, 3)
 
         # initialize logging boolean
         test_logger = False
 
         # call solver python interface with optional arguments
-        solver_py_interface(
+        solver(
             mock_obj_func,
             mock_update_orbs,
             3,
@@ -242,7 +242,7 @@ class PyInterfaceTests(unittest.TestCase):
 
         self.assertTrue(
             libtestsuite.test_solver_result() or not test_logger,
-            "solver_py_interface failed",
+            "test_solver_py_interface failed",
         )
         print("test_solver_py_interface PASSED")
 
@@ -276,30 +276,25 @@ class PyInterfaceTests(unittest.TestCase):
             return
 
         # call stability check python interface without optional arguments
-        stable, kappa = stability_check_py_interface(h_diag, mock_hess_x, 3)
+        stable, kappa = stability_check(h_diag, mock_hess_x, 3)
 
-        if stable:
-            print(
-                "test_stability_check_py_interface failed: Returned stability boolean "
-                "wrong."
-            )
-        self.assertFalse(
-            stable,
+        msg = (
             "test_stability_check_py_interface failed: Returned stability boolean "
-            "wrong.",
+            "wrong."
         )
+        if stable:
+            print(msg)
+        self.assertFalse(stable, msg)
+        msg = "test_stability_check_py_interface failed: Returned direction wrong."
         if not np.allclose(kappa, np.full(3, 1.0, dtype=np.float64)):
-            print("test_stability_check_py_interface failed: Returned direction wrong.")
-        self.assertTrue(
-            np.allclose(kappa, np.full(3, 1.0, dtype=np.float64)),
-            "test_stability_check_py_interface failed: Returned direction wrong.",
-        )
+            print(msg)
+        self.assertTrue(np.allclose(kappa, np.full(3, 1.0, dtype=np.float64)), msg)
 
         # initialize logging boolean
         test_logger = False
 
         # call stability check python interface with optional arguments
-        stable, kappa = stability_check_py_interface(
+        stable, kappa = stability_check(
             h_diag,
             mock_hess_x,
             3,

--- a/tests/c_interface_mock.f90
+++ b/tests/c_interface_mock.f90
@@ -66,7 +66,7 @@ contains
                                           n_micro_c_ptr, global_red_factor_c_ptr, &
                                           local_red_factor_c_ptr, seed_c_ptr, &
                                           verbose_c_ptr
-        logical(c_bool) :: error_c
+        integer(c_long) :: error_c
 
         type(c_funptr) :: hess_x_c_funptr
         procedure(update_orbs_c_type), pointer :: update_orbs_funptr
@@ -87,7 +87,8 @@ contains
                                     n_micro_ptr, seed_ptr, verbose_ptr
         procedure(logger_c_type), pointer :: logger_funptr
         character(:), allocatable, target :: message
-        logical(c_bool) :: error, converged
+        logical(c_bool) :: converged
+        integer(c_long) :: error
 
         ! get Fortran pointer to passed orbital update routine and call it
         call c_f_procpointer(cptr=update_orbs_c_funptr, fptr=update_orbs_funptr)
@@ -96,7 +97,7 @@ contains
                                    hess_x_c_funptr)
 
         ! check for error
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_solver_py_interface failed: Passed orbital "// &
                 "updating function returned error."
             test_solver_interface = .false.
@@ -108,7 +109,7 @@ contains
         error = hess_x_funptr(x, hess_x_c_ptr)
 
         ! check for error
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_solver_py_interface failed: Passed Hessian "// &
                 "linear transformation function returned error."
             test_solver_interface = .false.
@@ -146,7 +147,7 @@ contains
         error = obj_func_funptr(kappa, func)
 
         ! check for error
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_solver_py_interface failed: Passed objective "// &
                 "function returned error."
             test_solver_interface = .false.
@@ -206,7 +207,7 @@ contains
             call c_f_procpointer(cptr=precond_c_funptr, fptr=precond_funptr)
             residual = 1.0_c_double
             error = precond_funptr(residual, 5.0_c_double, precond_residual_c_ptr)
-            if (error) then
+            if (error /= 0) then
                 write (stderr, *) "test_solver_py_interface failed: Passed "// &
                     "preconditioner function returned error."
                 test_solver_interface = .false.
@@ -223,7 +224,7 @@ contains
             ! check result
             call c_f_procpointer(cptr=conv_check_c_funptr, fptr=conv_check_funptr)
             error = conv_check_funptr(converged)
-            if (error) then
+            if (error /= 0) then
                 write (stderr, *) "test_solver_py_interface failed: Passed "// &
                     "convergence check function returned error."
                 test_solver_interface = .false.
@@ -273,7 +274,7 @@ contains
         end if
 
         ! set return arguments
-        error_c = .false.
+        error_c = 0
 
         ! move on to optional argument test for next test
         solver_default = .false.
@@ -300,7 +301,7 @@ contains
         type(c_ptr), value, intent(in) :: jacobi_davidson_c_ptr, conv_tol_c_ptr, &
                                           n_random_trial_vectors_c_ptr, n_iter_c_ptr, &
                                           verbose_c_ptr
-        logical(c_bool) :: error_c
+        integer(c_long) :: error_c
 
         procedure(hess_x_c_type), pointer :: hess_x_funptr
         procedure(precond_c_type), pointer :: precond_funptr
@@ -312,7 +313,7 @@ contains
         integer(c_long), pointer :: n_random_trial_vectors_ptr, n_iter_ptr, verbose_ptr
         procedure(logger_c_type), pointer :: logger_funptr
         character(:), allocatable, target :: message
-        logical :: error
+        integer(c_long) :: error
 
         ! check if Hessian diagonal is passed correctly
         if (any(abs(h_diag_c - 3.0_c_double) > tol)) then
@@ -326,7 +327,7 @@ contains
         call c_f_procpointer(cptr=hess_x_c_funptr, fptr=hess_x_funptr)
         x = 1.0_c_double
         error = hess_x_funptr(x, hess_x_c_ptr)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_stability_check_py_interface failed: Passed "// &
                 "Hessian linear transformation function returned error."
             test_stability_check_interface = .false.
@@ -368,7 +369,7 @@ contains
             call c_f_procpointer(cptr=precond_c_funptr, fptr=precond_funptr)
             residual = 1.0_c_double
             error = precond_funptr(residual, 5.0_c_double, precond_residual_c_ptr)
-            if (error) then
+            if (error /= 0) then
                 write (stderr, *) "test_stability_check_py_interface failed: "// &
                     "Passed preconditioner function returned error."
                 test_stability_check_interface = .false.
@@ -407,7 +408,7 @@ contains
         ! set return arguments
         stable_c = .false.
         kappa_c = 1.0_c_double
-        error_c = .false.
+        error_c = 0
 
         ! move on to optional argument test for next test
         stability_check_default = .false.

--- a/tests/c_interface_mock.f90
+++ b/tests/c_interface_mock.f90
@@ -39,17 +39,16 @@ contains
 
     end function test_stability_check_result
 
-    subroutine mock_solver_c_wrapper(update_orbs_c_funptr, obj_func_c_funptr, &
-                                     n_param_c, error_c, precond_c_funptr, &
-                                     conv_check_c_funptr, stability_c_ptr, &
-                                     line_search_c_ptr, davidson_c_ptr, &
-                                     jacobi_davidson_c_ptr, &
-                                     prefer_jacobi_davidson_c_ptr, conv_tol_c_ptr, &
-                                     n_random_trial_vectors_c_ptr, &
-                                     start_trust_radius_c_ptr, n_macro_c_ptr, &
-                                     n_micro_c_ptr, global_red_factor_c_ptr, &
-                                     local_red_factor_c_ptr, seed_c_ptr, &
-                                     verbose_c_ptr, logger_c_funptr) &
+    function mock_solver_c_wrapper(update_orbs_c_funptr, obj_func_c_funptr, &
+                                   n_param_c, precond_c_funptr, conv_check_c_funptr, &
+                                   stability_c_ptr, line_search_c_ptr, davidson_c_ptr, &
+                                   jacobi_davidson_c_ptr, &
+                                   prefer_jacobi_davidson_c_ptr, conv_tol_c_ptr, &
+                                   n_random_trial_vectors_c_ptr, &
+                                   start_trust_radius_c_ptr, n_macro_c_ptr, &
+                                   n_micro_c_ptr, global_red_factor_c_ptr, &
+                                   local_red_factor_c_ptr, seed_c_ptr, verbose_c_ptr, &
+                                   logger_c_funptr) result(error_c) &
         bind(C, name="mock_solver")
         !
         ! this subroutine is a mock routine for the solver C wrapper subroutine
@@ -57,7 +56,6 @@ contains
         type(c_funptr), intent(in), value :: update_orbs_c_funptr, obj_func_c_funptr, &
                                              precond_c_funptr, conv_check_c_funptr, &
                                              logger_c_funptr
-        logical(c_bool), intent(out) :: error_c
         integer(c_long), intent(in), value :: n_param_c
         type(c_ptr), intent(in), value :: stability_c_ptr, line_search_c_ptr, &
                                           davidson_c_ptr, jacobi_davidson_c_ptr, &
@@ -68,6 +66,7 @@ contains
                                           n_micro_c_ptr, global_red_factor_c_ptr, &
                                           local_red_factor_c_ptr, seed_c_ptr, &
                                           verbose_c_ptr
+        logical(c_bool) :: error_c
 
         type(c_funptr) :: hess_x_c_funptr
         procedure(update_orbs_c_type), pointer :: update_orbs_funptr
@@ -88,16 +87,32 @@ contains
                                     n_micro_ptr, seed_ptr, verbose_ptr
         procedure(logger_c_type), pointer :: logger_funptr
         character(:), allocatable, target :: message
+        logical(c_bool) :: error, converged
 
         ! get Fortran pointer to passed orbital update routine and call it
         call c_f_procpointer(cptr=update_orbs_c_funptr, fptr=update_orbs_funptr)
         kappa = 1.0_c_double
-        call update_orbs_funptr(kappa, func, grad_c_ptr, h_diag_c_ptr, hess_x_c_funptr)
+        error = update_orbs_funptr(kappa, func, grad_c_ptr, h_diag_c_ptr, &
+                                   hess_x_c_funptr)
+
+        ! check for error
+        if (error) then
+            write (stderr, *) "test_solver_py_interface failed: Passed orbital "// &
+                "updating function returned error."
+            test_solver_interface = .false.
+        end if
 
         ! get Fortran pointer to Hessian linear transformation function and call it
         call c_f_procpointer(cptr=hess_x_c_funptr, fptr=hess_x_funptr)
         x = 1.0_c_double
-        call hess_x_funptr(x, hess_x_c_ptr)
+        error = hess_x_funptr(x, hess_x_c_ptr)
+
+        ! check for error
+        if (error) then
+            write (stderr, *) "test_solver_py_interface failed: Passed Hessian "// &
+                "linear transformation function returned error."
+            test_solver_interface = .false.
+        end if
 
         ! get Fortran pointers to generated arrays and check whether these are filled
         ! correctly
@@ -128,7 +143,14 @@ contains
 
         ! get Fortran pointer to passed objective function and call it
         call c_f_procpointer(cptr=obj_func_c_funptr, fptr=obj_func_funptr)
-        func = obj_func_funptr(kappa)
+        error = obj_func_funptr(kappa, func)
+
+        ! check for error
+        if (error) then
+            write (stderr, *) "test_solver_py_interface failed: Passed objective "// &
+                "function returned error."
+            test_solver_interface = .false.
+        end if
 
         ! check if generated function value is correct
         if (abs(func - 3.0_c_double) > tol) then
@@ -179,13 +201,16 @@ contains
                 test_solver_interface = .false.
             end if
 
-            ! get Fortran pointer to passed preconditioner function and call it
+            ! get Fortran pointer to passed preconditioner function, call it and check
+            ! result
             call c_f_procpointer(cptr=precond_c_funptr, fptr=precond_funptr)
             residual = 1.0_c_double
-            call precond_funptr(residual, 5.0_c_double, precond_residual_c_ptr)
-
-            ! convert to Fortran pointer and check if generated preconditioned residual 
-            ! is correct
+            error = precond_funptr(residual, 5.0_c_double, precond_residual_c_ptr)
+            if (error) then
+                write (stderr, *) "test_solver_py_interface failed: Passed "// &
+                    "preconditioner function returned error."
+                test_solver_interface = .false.
+            end if
             call c_f_pointer(cptr=precond_residual_c_ptr, fptr=precond_residual_ptr, &
                              shape=[n_param_c])
             if (any(abs(precond_residual_ptr - 5.0_c_double) > tol)) then
@@ -197,7 +222,13 @@ contains
             ! get Fortran pointer to passed convergence check function, call it and 
             ! check result
             call c_f_procpointer(cptr=conv_check_c_funptr, fptr=conv_check_funptr)
-            if (.not. conv_check_funptr()) then
+            error = conv_check_funptr(converged)
+            if (error) then
+                write (stderr, *) "test_solver_py_interface failed: Passed "// &
+                    "convergence check function returned error."
+                test_solver_interface = .false.
+            end if
+            if (.not. converged) then
                 write (stderr, *) "test_solver_py_interface failed: Returned "// &
                     "convergence logical of convergence check function wrong."
                 test_solver_interface = .false.
@@ -247,15 +278,14 @@ contains
         ! move on to optional argument test for next test
         solver_default = .false.
 
-    end subroutine mock_solver_c_wrapper
+    end function mock_solver_c_wrapper
 
-    subroutine mock_stability_check_c_wrapper(h_diag_c, hess_x_c_funptr, n_param_c, &
-                                              stable_c, kappa_c, error_c, &
-                                              precond_c_funptr, jacobi_davidson_c_ptr, &
-                                              conv_tol_c_ptr, &
-                                              n_random_trial_vectors_c_ptr, &
-                                              n_iter_c_ptr, verbose_c_ptr, &
-                                              logger_c_funptr) &
+    function mock_stability_check_c_wrapper(h_diag_c, hess_x_c_funptr, n_param_c, &
+                                            stable_c, kappa_c, precond_c_funptr, &
+                                            jacobi_davidson_c_ptr, conv_tol_c_ptr, &
+                                            n_random_trial_vectors_c_ptr, &
+                                            n_iter_c_ptr, verbose_c_ptr, &
+                                            logger_c_funptr) result(error_c) &
         bind(C, name="mock_stability_check")
         !
         ! this subroutine is a mock routine for the stability check C wrapper
@@ -265,11 +295,12 @@ contains
         real(c_double), intent(in), dimension(n_param_c) :: h_diag_c
         type(c_funptr), intent(in), value :: hess_x_c_funptr, precond_c_funptr, &
                                              logger_c_funptr
-        logical(c_bool), intent(out) :: stable_c, error_c
+        logical(c_bool), intent(out) :: stable_c
         real(c_double), intent(out) :: kappa_c(n_param_c)
         type(c_ptr), value, intent(in) :: jacobi_davidson_c_ptr, conv_tol_c_ptr, &
                                           n_random_trial_vectors_c_ptr, n_iter_c_ptr, &
                                           verbose_c_ptr
+        logical(c_bool) :: error_c
 
         procedure(hess_x_c_type), pointer :: hess_x_funptr
         procedure(precond_c_type), pointer :: precond_funptr
@@ -281,6 +312,7 @@ contains
         integer(c_long), pointer :: n_random_trial_vectors_ptr, n_iter_ptr, verbose_ptr
         procedure(logger_c_type), pointer :: logger_funptr
         character(:), allocatable, target :: message
+        logical :: error
 
         ! check if Hessian diagonal is passed correctly
         if (any(abs(h_diag_c - 3.0_c_double) > tol)) then
@@ -289,13 +321,16 @@ contains
             test_stability_check_interface = .false.
         end if
 
-        ! get Fortran pointer to Hessian linear transformation function and call it
+        ! get Fortran pointer to Hessian linear transformation function, call it and 
+        ! check result
         call c_f_procpointer(cptr=hess_x_c_funptr, fptr=hess_x_funptr)
         x = 1.0_c_double
-        call hess_x_funptr(x, hess_x_c_ptr)
-
-        ! get Fortran pointer to generated array and check whether it is filled
-        ! correctly
+        error = hess_x_funptr(x, hess_x_c_ptr)
+        if (error) then
+            write (stderr, *) "test_stability_check_py_interface failed: Passed "// &
+                "Hessian linear transformation function returned error."
+            test_stability_check_interface = .false.
+        end if
         call c_f_pointer(cptr=hess_x_c_ptr, fptr=hess_x_ptr, shape=[n_param_c])
         if (any(abs(hess_x_ptr - 4.0_c_double) > tol)) then
             write (stderr, *) "test_stability_check_py_interface failed: Returned "// &
@@ -329,13 +364,15 @@ contains
                 test_stability_check_interface = .false.
             end if
 
-            ! get Fortran pointer to passed precond function and call it
+            ! get Fortran pointer to passed precond function, call it and check result
             call c_f_procpointer(cptr=precond_c_funptr, fptr=precond_funptr)
             residual = 1.0_c_double
-            call precond_funptr(residual, 5.0_c_double, precond_residual_c_ptr)
-
-            ! convert to Fortran pointer and check if generated preconditioned residual 
-            ! is correct
+            error = precond_funptr(residual, 5.0_c_double, precond_residual_c_ptr)
+            if (error) then
+                write (stderr, *) "test_stability_check_py_interface failed: "// &
+                    "Passed preconditioner function returned error."
+                test_stability_check_interface = .false.
+            end if
             call c_f_pointer(cptr=precond_residual_c_ptr, fptr=precond_residual_ptr, &
                              shape=[n_param_c])
             if (any(abs(precond_residual_ptr - 5.0_c_double) > tol)) then
@@ -375,6 +412,6 @@ contains
         ! move on to optional argument test for next test
         stability_check_default = .false.
 
-    end subroutine mock_stability_check_c_wrapper
+    end function mock_stability_check_c_wrapper
 
 end module c_interface_mock

--- a/tests/c_interface_unit_tests.f90
+++ b/tests/c_interface_unit_tests.f90
@@ -6,7 +6,7 @@
 
 module c_interface_unit_tests
 
-    use opentrustregion, only: rp, stderr
+    use opentrustregion, only: rp, ip, stderr
     use, intrinsic :: iso_c_binding, only: c_long, c_double, c_bool, c_ptr, c_loc, &
                                            c_null_ptr, c_funptr, c_funloc, &
                                            c_null_funptr, c_char
@@ -35,7 +35,7 @@ contains
         real(c_double), intent(out) :: func
         type(c_ptr), intent(out) :: grad_c_ptr, h_diag_c_ptr
         type(c_funptr), intent(out) :: hess_x_c_funptr
-        logical(c_bool) :: error
+        integer(c_long) :: error
 
         func = sum(kappa(:n_param))
 
@@ -47,7 +47,7 @@ contains
 
         hess_x_c_funptr = c_funloc(mock_hess_x)
 
-        error = .false.
+        error = 0
 
     end function mock_update_orbs
 
@@ -58,12 +58,12 @@ contains
         !
         real(c_double), intent(in) :: x(*)
         type(c_ptr), intent(out) :: hess_x_c_ptr
-        logical(c_bool) :: error
+        integer(c_long) :: error
 
         hess_x_c = 4*x(:n_param)
         hess_x_c_ptr = c_loc(hess_x_c)
 
-        error = .false.
+        error = 0
 
     end function mock_hess_x
 
@@ -73,11 +73,11 @@ contains
         !
         real(c_double), intent(in) :: kappa(*)
         real(c_double), intent(out) :: func
-        logical(c_bool) :: error
+        integer(c_long) :: error
 
         func = sum(kappa(:n_param))
 
-        error = .false.
+        error = 0
 
     end function mock_obj_func
 
@@ -87,12 +87,12 @@ contains
         !
         real(c_double), intent(in) :: residual(*), mu
         type(c_ptr), intent(out) :: precond_residual_c_ptr
-        logical(c_bool) :: error
+        integer(c_long) :: error
 
         precond_residual_c = mu*residual(:n_param)
         precond_residual_c_ptr = c_loc(precond_residual_c)
 
-        error = .false.
+        error = 0
 
     end function mock_precond
 
@@ -101,11 +101,11 @@ contains
         ! this function is a test function for the convergence check function
         !
         logical(c_bool), intent(out) :: converged
-        logical(c_bool) :: error
+        integer(c_long) :: error
 
         converged = .true.
 
-        error = .false.
+        error = 0
         
     end function mock_conv_check
 
@@ -132,7 +132,7 @@ contains
                           precond_c_funptr = c_null_funptr, &
                           conv_check_c_funptr = c_null_funptr, &
                           logger_c_funptr = c_null_funptr
-        logical(c_bool) :: error
+        integer(c_long) :: error
         integer(c_long), target :: n_random_trial_vectors = 5_c_long, &
                                    n_macro = 300_c_long, n_micro = 200_c_long, &
                                    seed = 33_c_long, verbose = 3_c_long
@@ -183,7 +183,7 @@ contains
         test_solver_c_wrapper = test_passed
 
         ! check if output variables are as expected
-        if (error) then
+        if (error /= 0) then
             test_solver_c_wrapper = .false.
             write (stderr, *) "test_solver_c_wrapper failed: Returned error "// &
                 "boolean wrong."
@@ -230,7 +230,7 @@ contains
         end if
 
         ! check if output variables are as expected
-        if (error) then
+        if (error /= 0) then
             test_solver_c_wrapper = .false.
             write (stderr, *) "test_solver_c_wrapper failed: Returned error "// &
                 "boolean wrong."
@@ -251,7 +251,8 @@ contains
         real(c_double), dimension(n_param) :: kappa
         type(c_funptr) :: hess_x_c_funptr, precond_c_funptr = c_null_funptr, &
                           logger_c_funptr = c_null_funptr
-        logical(c_bool) :: stable, error
+        logical(c_bool) :: stable
+        integer(c_long) :: error
         logical(c_bool), target :: jacobi_davidson = .false.
         real(c_double), target :: conv_tol = 1e-3_c_double
         integer(c_long), target :: n_random_trial_vectors = 3_c_long, &
@@ -297,7 +298,7 @@ contains
                 "direction wrong."
         end if
 
-        if (error) then
+        if (error /= 0) then
             test_stability_check_c_wrapper = .false.
             write (stderr, *) "test_stability_check_c_wrapper failed: Returned "// &
                 "error boolean wrong."
@@ -342,7 +343,7 @@ contains
                 "direction wrong."
         end if
 
-        if (error) then
+        if (error /= 0) then
             test_stability_check_c_wrapper = .false.
             write (stderr, *) "test_stability_check_c_wrapper failed: Returned "// &
                 "error boolean wrong."
@@ -364,7 +365,7 @@ contains
         real(rp), dimension(n_param) :: kappa, grad, h_diag, x, hess_x
         real(rp) :: func
         procedure(hess_x_type), pointer :: hess_x_funptr
-        logical :: error
+        integer(ip) :: error
 
         ! assume tests pass
         test_update_orbs_c_wrapper = .true.
@@ -379,7 +380,7 @@ contains
         call update_orbs_c_wrapper(kappa, func, grad, h_diag, hess_x_funptr, error)
 
         ! check if error is as expected
-        if (error) then
+        if (error /= 0) then
             test_update_orbs_c_wrapper = .false.
             write (stderr, *) "test_update_orbs_c_wrapper failed: Returned error."
         end if
@@ -410,7 +411,7 @@ contains
         hess_x = hess_x_funptr(x, error)
 
         ! check if error is as expected
-        if (error) then
+        if (error /= 0) then
             test_update_orbs_c_wrapper = .false.
             write (stderr, *) "test_update_orbs_c_wrapper failed: Returned Hessian "// &
                 "linear transformation function produced error."
@@ -433,7 +434,7 @@ contains
         use c_interface, only: hess_x_before_wrapping, hess_x_c_wrapper
 
         real(rp), dimension(n_param) :: x, hess_x
-        logical :: error
+        integer(ip) :: error
 
         ! assume tests pass
         test_hess_x_c_wrapper = .true.
@@ -446,7 +447,7 @@ contains
         hess_x = hess_x_c_wrapper(x, error)
 
         ! check if error is as expected
-        if (error) then
+        if (error /= 0) then
             test_hess_x_c_wrapper = .false.
             write (stderr, *) "test_hess_x_c_wrapper failed: Returned error."
         end if
@@ -468,7 +469,7 @@ contains
         use c_interface, only: obj_func_before_wrapping, obj_func_c_wrapper
 
         real(rp) :: kappa(n_param), obj_func
-        logical :: error
+        integer(ip) :: error
 
         ! assume tests pass
         test_obj_func_c_wrapper = .true.
@@ -483,7 +484,7 @@ contains
         obj_func = obj_func_c_wrapper(kappa, error)
 
         ! check if error is as expected
-        if (error) then
+        if (error /= 0) then
             test_obj_func_c_wrapper = .false.
             write (stderr, *) "test_obj_func_c_wrapper failed: Returned error."
         end if
@@ -504,7 +505,7 @@ contains
         use c_interface, only: precond_before_wrapping, precond_c_wrapper
 
         real(rp), dimension(n_param) :: residual, precond_residual
-        logical :: error
+        integer(ip) :: error
 
         ! assume tests pass
         test_precond_c_wrapper = .true.
@@ -519,7 +520,7 @@ contains
         precond_residual = precond_c_wrapper(residual, 5.d0, error)
 
         ! check if error is as expected
-        if (error) then
+        if (error /= 0) then
             test_precond_c_wrapper = .false.
             write (stderr, *) "test_precond_c_wrapper failed: Returned error."
         end if
@@ -539,7 +540,8 @@ contains
         !
         use c_interface, only: conv_check_before_wrapping, conv_check_c_wrapper
 
-        logical :: converged, error
+        logical :: converged
+        integer(ip) :: error
 
         ! assume tests pass
         test_conv_check_c_wrapper = .true.
@@ -551,7 +553,7 @@ contains
         converged = conv_check_c_wrapper(error)
 
         ! check if error is as expected
-        if (error) then
+        if (error /= 0) then
             test_conv_check_c_wrapper = .false.
             write (stderr, *) "test_conv_check_c_wrapper failed: Returned error."
         end if
@@ -570,8 +572,6 @@ contains
         ! this function tests the C wrapper for the logging function
         !
         use c_interface, only: logger_before_wrapping, logger_c_wrapper
-
-        logical :: error
 
         ! assume tests pass
         test_logger_c_wrapper = .true.

--- a/tests/c_interface_unit_tests.f90
+++ b/tests/c_interface_unit_tests.f90
@@ -26,8 +26,8 @@ module c_interface_unit_tests
 
 contains
 
-    subroutine mock_update_orbs(kappa, func, grad_c_ptr, h_diag_c_ptr, &
-                                hess_x_c_funptr) bind(C)
+    function mock_update_orbs(kappa, func, grad_c_ptr, h_diag_c_ptr, &
+                                hess_x_c_funptr) result(error) bind(C)
         !
         ! this subroutine is a test subroutine for the orbital update C function
         !
@@ -35,6 +35,7 @@ contains
         real(c_double), intent(out) :: func
         type(c_ptr), intent(out) :: grad_c_ptr, h_diag_c_ptr
         type(c_funptr), intent(out) :: hess_x_c_funptr
+        logical(c_bool) :: error
 
         func = sum(kappa(:n_param))
 
@@ -46,53 +47,66 @@ contains
 
         hess_x_c_funptr = c_funloc(mock_hess_x)
 
-    end subroutine mock_update_orbs
+        error = .false.
 
-    subroutine mock_hess_x(x, hess_x_c_ptr) bind(C)
+    end function mock_update_orbs
+
+    function mock_hess_x(x, hess_x_c_ptr) result(error) bind(C)
         !
         ! this subroutine is a test subroutine for the Hessian linear transformation
         ! C function
         !
         real(c_double), intent(in) :: x(*)
         type(c_ptr), intent(out) :: hess_x_c_ptr
+        logical(c_bool) :: error
 
         hess_x_c = 4*x(:n_param)
         hess_x_c_ptr = c_loc(hess_x_c)
 
-    end subroutine mock_hess_x
+        error = .false.
 
-    function mock_obj_func(kappa) result(func) bind(C)
+    end function mock_hess_x
+
+    function mock_obj_func(kappa, func) result(error) bind(C)
         !
         ! this function is a test function for the C objective function
         !
         real(c_double), intent(in) :: kappa(*)
-
-        real(c_double) :: func
+        real(c_double), intent(out) :: func
+        logical(c_bool) :: error
 
         func = sum(kappa(:n_param))
 
+        error = .false.
+
     end function mock_obj_func
 
-    subroutine mock_precond(residual, mu, precond_residual_c_ptr) bind(C)
+    function mock_precond(residual, mu, precond_residual_c_ptr) result(error) bind(C)
         !
         ! this function is a test function for the C preconditioner function
         !
         real(c_double), intent(in) :: residual(*), mu
         type(c_ptr), intent(out) :: precond_residual_c_ptr
+        logical(c_bool) :: error
 
         precond_residual_c = mu*residual(:n_param)
         precond_residual_c_ptr = c_loc(precond_residual_c)
 
-    end subroutine mock_precond
+        error = .false.
 
-    function mock_conv_check() result(converged) bind(C)
+    end function mock_precond
+
+    function mock_conv_check(converged) result(error) bind(C)
         !
         ! this function is a test function for the convergence check function
         !
-        logical(c_bool) :: converged
+        logical(c_bool), intent(out) :: converged
+        logical(c_bool) :: error
 
         converged = .true.
 
+        error = .false.
+        
     end function mock_conv_check
 
     subroutine mock_logger(message_c) bind(C)
@@ -154,14 +168,15 @@ contains
 
         ! call solver first without associated optional arguments which should produce
         ! default values
-        call solver_c_wrapper(update_orbs_c_funptr, obj_func_c_funptr, n_param, error, &
-                              precond_c_funptr, conv_check_c_funptr, stability_c_ptr, &
-                              line_search_c_ptr, davidson_c_ptr, &
-                              jacobi_davidson_c_ptr, prefer_jacobi_davidson_c_ptr, &
-                              conv_tol_c_ptr, n_random_trial_vectors_c_ptr, &
-                              start_trust_radius_c_ptr, n_macro_c_ptr, n_micro_c_ptr, &
-                              global_red_factor_c_ptr, local_red_factor_c_ptr, &
-                              seed_c_ptr, verbose_c_ptr, logger_c_funptr)
+        error = solver_c_wrapper(update_orbs_c_funptr, obj_func_c_funptr, n_param, &
+                                 precond_c_funptr, conv_check_c_funptr, &
+                                 stability_c_ptr, line_search_c_ptr, davidson_c_ptr, &
+                                 jacobi_davidson_c_ptr, prefer_jacobi_davidson_c_ptr, &
+                                 conv_tol_c_ptr, n_random_trial_vectors_c_ptr, &
+                                 start_trust_radius_c_ptr, n_macro_c_ptr, &
+                                 n_micro_c_ptr, global_red_factor_c_ptr, &
+                                 local_red_factor_c_ptr, seed_c_ptr, verbose_c_ptr, &
+                                 logger_c_funptr)
                               
 
         ! check if test has passed
@@ -197,14 +212,15 @@ contains
         test_logger = .true.     
 
         ! call solver with associated optional arguments
-        call solver_c_wrapper(update_orbs_c_funptr, obj_func_c_funptr, n_param, error, &
-                              precond_c_funptr, conv_check_c_funptr, stability_c_ptr, &
-                              line_search_c_ptr, davidson_c_ptr, &
-                              jacobi_davidson_c_ptr, prefer_jacobi_davidson_c_ptr, &
-                              conv_tol_c_ptr, n_random_trial_vectors_c_ptr, &
-                              start_trust_radius_c_ptr, n_macro_c_ptr, n_micro_c_ptr, &
-                              global_red_factor_c_ptr, local_red_factor_c_ptr, &
-                              seed_c_ptr, verbose_c_ptr, logger_c_funptr)
+        error = solver_c_wrapper(update_orbs_c_funptr, obj_func_c_funptr, n_param, &
+                                 precond_c_funptr, conv_check_c_funptr, &
+                                 stability_c_ptr, line_search_c_ptr, davidson_c_ptr, &
+                                 jacobi_davidson_c_ptr, prefer_jacobi_davidson_c_ptr, &
+                                 conv_tol_c_ptr, n_random_trial_vectors_c_ptr, &
+                                 start_trust_radius_c_ptr, n_macro_c_ptr, &
+                                 n_micro_c_ptr, global_red_factor_c_ptr, &
+                                 local_red_factor_c_ptr, seed_c_ptr, verbose_c_ptr, &
+                                 logger_c_funptr)
 
         ! check if logging subroutine was correctly called
         if (.not. test_logger) then
@@ -259,11 +275,11 @@ contains
 
         ! call stability check first without associated optional arguments which should 
         ! produce default values
-        call stability_check_c_wrapper(h_diag_c, hess_x_c_funptr, n_param, stable, &
-                                       kappa, error, precond_c_funptr, &
-                                       jacobi_davidson_c_ptr, conv_tol_c_ptr, &
-                                       n_random_trial_vectors_c_ptr, n_iter_c_ptr, &
-                                       verbose_c_ptr, logger_c_funptr)
+        error = stability_check_c_wrapper(h_diag_c, hess_x_c_funptr, n_param, stable, &
+                                          kappa, precond_c_funptr, &
+                                          jacobi_davidson_c_ptr, conv_tol_c_ptr, &
+                                          n_random_trial_vectors_c_ptr, n_iter_c_ptr, &
+                                          verbose_c_ptr, logger_c_funptr)
 
         ! check if test has passed
         test_stability_check_c_wrapper = test_passed
@@ -300,11 +316,11 @@ contains
         test_logger = .true.
 
         ! call stability check with associated optional arguments
-        call stability_check_c_wrapper(h_diag_c, hess_x_c_funptr, n_param, stable, &
-                                       kappa, error, precond_c_funptr, &
-                                       jacobi_davidson_c_ptr, conv_tol_c_ptr, &
-                                       n_random_trial_vectors_c_ptr, n_iter_c_ptr, &
-                                       verbose_c_ptr, logger_c_funptr)
+        error = stability_check_c_wrapper(h_diag_c, hess_x_c_funptr, n_param, stable, &
+                                          kappa, precond_c_funptr, &
+                                          jacobi_davidson_c_ptr, conv_tol_c_ptr, &
+                                          n_random_trial_vectors_c_ptr, n_iter_c_ptr, &
+                                          verbose_c_ptr, logger_c_funptr)
 
         ! check if logging subroutine was correctly called
         if (.not. test_logger) then
@@ -348,6 +364,7 @@ contains
         real(rp), dimension(n_param) :: kappa, grad, h_diag, x, hess_x
         real(rp) :: func
         procedure(hess_x_type), pointer :: hess_x_funptr
+        logical :: error
 
         ! assume tests pass
         test_update_orbs_c_wrapper = .true.
@@ -359,7 +376,13 @@ contains
         update_orbs_before_wrapping => mock_update_orbs
 
         ! call orbital updating subroutine
-        call update_orbs_c_wrapper(kappa, func, grad, h_diag, hess_x_funptr)
+        call update_orbs_c_wrapper(kappa, func, grad, h_diag, hess_x_funptr, error)
+
+        ! check if error is as expected
+        if (error) then
+            test_update_orbs_c_wrapper = .false.
+            write (stderr, *) "test_update_orbs_c_wrapper failed: Returned error."
+        end if
 
         ! check if function value is as expected
         if (abs(func - 3.d0) > tol) then
@@ -382,9 +405,18 @@ contains
                 "diagonal wrong."
         end if
 
-        ! check if Hessian linear transformation is as expected
+        ! call Hessian linear transformation function
         x = 1.d0
-        hess_x = hess_x_funptr(x)
+        hess_x = hess_x_funptr(x, error)
+
+        ! check if error is as expected
+        if (error) then
+            test_update_orbs_c_wrapper = .false.
+            write (stderr, *) "test_update_orbs_c_wrapper failed: Returned Hessian "// &
+                "linear transformation function produced error."
+        end if
+
+        ! check if Hessian linear transformation is as expected
         if (any(abs(hess_x - 4.d0) > tol)) then
             test_update_orbs_c_wrapper = .false.
             write (stderr, *) "test_update_orbs_c_wrapper failed: Returned Hessian "// &
@@ -401,6 +433,7 @@ contains
         use c_interface, only: hess_x_before_wrapping, hess_x_c_wrapper
 
         real(rp), dimension(n_param) :: x, hess_x
+        logical :: error
 
         ! assume tests pass
         test_hess_x_c_wrapper = .true.
@@ -408,9 +441,17 @@ contains
         ! inject mock subroutine
         hess_x_before_wrapping => mock_hess_x
 
-        ! check if Hessian linear transformation is as expected
+        ! call function
         x = 1.d0
-        hess_x = hess_x_c_wrapper(x)
+        hess_x = hess_x_c_wrapper(x, error)
+
+        ! check if error is as expected
+        if (error) then
+            test_hess_x_c_wrapper = .false.
+            write (stderr, *) "test_hess_x_c_wrapper failed: Returned error."
+        end if
+
+        ! check if Hessian linear transformation is as expected
         if (any(abs(hess_x - 4.d0) > tol)) then
             test_hess_x_c_wrapper = .false.
             write (stderr, *) "test_hess_x_c_wrapper failed: Returned Hessian "// &
@@ -426,7 +467,8 @@ contains
         !
         use c_interface, only: obj_func_before_wrapping, obj_func_c_wrapper
 
-        real(rp) :: kappa(n_param)
+        real(rp) :: kappa(n_param), obj_func
+        logical :: error
 
         ! assume tests pass
         test_obj_func_c_wrapper = .true.
@@ -434,13 +476,22 @@ contains
         ! initialize kappa
         kappa = 1.d0
 
-        ! inject mock subroutine
+        ! inject mock function
         obj_func_before_wrapping => mock_obj_func
 
-        ! check if function value is as expected
-        if (abs(obj_func_c_wrapper(kappa) - 3.d0) > tol) then
+        ! call function
+        obj_func = obj_func_c_wrapper(kappa, error)
+
+        ! check if error is as expected
+        if (error) then
             test_obj_func_c_wrapper = .false.
-            write (stderr, *) "test_obj_func_c_wrapper failed: returned objective "// &
+            write (stderr, *) "test_obj_func_c_wrapper failed: Returned error."
+        end if
+
+        ! check if function value is as expected
+        if (abs(obj_func - 3.d0) > tol) then
+            test_obj_func_c_wrapper = .false.
+            write (stderr, *) "test_obj_func_c_wrapper failed: Returned objective "// &
                 "function wrong."
         end if
 
@@ -453,6 +504,7 @@ contains
         use c_interface, only: precond_before_wrapping, precond_c_wrapper
 
         real(rp), dimension(n_param) :: residual, precond_residual
+        logical :: error
 
         ! assume tests pass
         test_precond_c_wrapper = .true.
@@ -463,8 +515,16 @@ contains
         ! inject mock subroutine
         precond_before_wrapping => mock_precond
 
-        ! check if function value is as expected
-        precond_residual = precond_c_wrapper(residual, 5.d0)
+        ! call function
+        precond_residual = precond_c_wrapper(residual, 5.d0, error)
+
+        ! check if error is as expected
+        if (error) then
+            test_precond_c_wrapper = .false.
+            write (stderr, *) "test_precond_c_wrapper failed: Returned error."
+        end if
+
+        ! check if preconditioned residual is as expected
         if (any(abs(precond_residual - 5.d0) > tol)) then
             test_precond_c_wrapper = .false.
             write (stderr, *) "test_precond_c_wrapper failed: Returned "// &
@@ -479,14 +539,25 @@ contains
         !
         use c_interface, only: conv_check_before_wrapping, conv_check_c_wrapper
 
+        logical :: converged, error
+
         ! assume tests pass
         test_conv_check_c_wrapper = .true.
 
-        ! inject mock subroutine
+        ! inject mock function
         conv_check_before_wrapping => mock_conv_check
 
-        ! check if function value is as expected
-        if (.not. conv_check_c_wrapper()) then
+        ! call function
+        converged = conv_check_c_wrapper(error)
+
+        ! check if error is as expected
+        if (error) then
+            test_conv_check_c_wrapper = .false.
+            write (stderr, *) "test_conv_check_c_wrapper failed: Returned error."
+        end if
+
+        ! check if convergence boolean is as expected
+        if (.not. converged) then
             test_conv_check_c_wrapper = .false.
             write (stderr, *) "test_conv_check_c_wrapper failed: Returned "// &
                 "convergence logical wrong."
@@ -500,15 +571,19 @@ contains
         !
         use c_interface, only: logger_before_wrapping, logger_c_wrapper
 
+        logical :: error
+
         ! assume tests pass
         test_logger_c_wrapper = .true.
 
         ! inject mock subroutine
         logger_before_wrapping => mock_logger
 
-        ! check if function value is as expected
+        ! call subroutine
         test_logger = .false.
         call logger_c_wrapper("test")
+
+        ! check if logging test boolean is as expected
         if (.not. test_logger) then
             test_logger_c_wrapper = .false.
             write (stderr, *) "test_logger_c_wrapper failed: Returned logging "// &

--- a/tests/opentrustregion_mock.f90
+++ b/tests/opentrustregion_mock.f90
@@ -43,7 +43,7 @@ contains
         procedure(update_orbs_type), intent(in), pointer :: update_orbs_funptr
         procedure(obj_func_type), intent(in), pointer :: obj_func_funptr
         integer(ip), intent(in) :: n_param
-        logical, intent(out) :: error
+        integer(ip), intent(out) :: error
         procedure(precond_type), intent(in), pointer, optional :: precond_funptr
         procedure(conv_check_type), intent(in), pointer, optional :: conv_check_funptr
         logical, intent(in), optional :: stability, line_search, davidson, &
@@ -65,7 +65,7 @@ contains
         ! check if passed orbital updating subroutine produces correct quantities
         kappa = 1.d0
         call update_orbs_funptr(kappa, func, grad, h_diag, hess_x_funptr, error)
-        if (error) then
+        if (error /= 0) then
             test_passed = .false.
             write (stderr, *) "test_solver_c_wrapper failed: Passed orbital "// &
                 "updating function produced error."
@@ -87,7 +87,7 @@ contains
         end if
         x = 1.d0
         hess_x = hess_x_funptr(x, error)
-        if (error) then
+        if (error /= 0) then
             test_passed = .false.
             write (stderr, *) "test_solver_c_wrapper failed: Hessian linear "// &
                 "transformation function returned by passed orbital updating "// &
@@ -102,7 +102,7 @@ contains
 
         ! check if passed objective function produces correct quantities
         func = obj_func_funptr(kappa, error)
-        if (error) then
+        if (error /= 0) then
             test_passed = .false.
             write (stderr, *) "test_solver_c_wrapper failed: Passed objective "// &
                 "function produced error."
@@ -121,7 +121,7 @@ contains
         end if
 
         ! set output quantities
-        error = .false.
+        error = 0
 
         ! check if optional preconditioner function is correctly passed
         if (solver_default) then
@@ -144,7 +144,7 @@ contains
             end if
             residual = 1.d0
             residual = precond_funptr(residual, 5.d0, error)
-            if (error) then
+            if (error /= 0) then
                 test_passed = .false.
                 write (stderr, *) "test_solver_c_wrapper failed: Passed "// &
                     "preconditioner function produced error."
@@ -176,7 +176,7 @@ contains
                     "convergence check function not associated with value."
             end if
             converged = conv_check_funptr(error)
-            if (error) then
+            if (error /= 0) then
                 test_passed = .false.
                 write (stderr, *) "test_solver_c_wrapper failed: Passed "// &
                     "convergence check function produced error."
@@ -277,7 +277,8 @@ contains
 
         real(rp), intent(in) :: h_diag(:)
         procedure(hess_x_type), intent(in), pointer :: hess_x_funptr
-        logical, intent(out) :: stable, error
+        logical, intent(out) :: stable
+        integer(ip), intent(out) :: error
         real(rp), intent(out) :: kappa(:)
         procedure(precond_type), intent(in), pointer, optional :: precond_funptr
         logical, intent(in), optional :: jacobi_davidson
@@ -301,7 +302,7 @@ contains
         ! quantity
         x = 1.d0
         hess_x = hess_x_funptr(x, error)
-        if (error) then
+        if (error /= 0) then
             test_passed = .false.
             write (stderr, *) "test_stability_check_c_wrapper failed: Passed "// &
                 "Hessian linear transformation function produced error."
@@ -316,7 +317,7 @@ contains
         ! set output quantities
         stable = .false.
         kappa = 1.d0
-        error = .false.
+        error = 0
 
         ! check if optional preconditioner function is correctly passed
         if (stability_check_default) then
@@ -339,7 +340,7 @@ contains
             end if
             residual = 1.d0
             residual = precond_funptr(residual, 5.d0, error)
-            if (error) then
+            if (error /= 0) then
                 test_passed = .false.
                 write (stderr, *) "test_stability_check_c_wrapper failed: Passed "// &
                     "preconditioner function produced error."

--- a/tests/opentrustregion_system_tests.f90
+++ b/tests/opentrustregion_system_tests.f90
@@ -34,10 +34,10 @@ contains
         procedure(update_orbs_type), pointer :: update_orbs_funptr
         procedure(obj_func_type), pointer :: obj_func_funptr
         procedure(hess_x_type), pointer :: hess_x_funptr
-        integer(ip) :: ios
+        integer(ip) :: ios, error
         real(rp), allocatable :: kappa(:), grad(:), h_diag(:)
         real(rp) :: func
-        logical :: stable, error
+        logical :: stable
 
         ! assume tests pass
         test_h2o_atomic_fb = .true.
@@ -82,9 +82,9 @@ contains
         call solver(update_orbs_funptr, obj_func_funptr, n_param, error)
 
         ! check if error has occured
-        if (error) then
-            write (stderr, *) "test_h2o_atomic_fb failed: Solver subroutine produced "// &
-                "error."
+        if (error /= 0) then
+            write (stderr, *) "test_h2o_atomic_fb failed: Solver subroutine "// &
+                "produced error."
             test_h2o_atomic_fb = .false.
         end if
 
@@ -94,7 +94,7 @@ contains
         call update_orbs(kappa, func, grad, h_diag, hess_x_funptr, error)
 
         ! check if error has occured
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_h2o_atomic_fb failed: Orbital updating "// &
             "subroutine produced error."
             test_h2o_atomic_fb = .false.
@@ -104,7 +104,7 @@ contains
         call stability_check(h_diag, hess_x_funptr, stable, kappa, error)
 
         ! check if error has occured
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_h2o_atomic_fb failed: Stability check "// &
             "subroutine produced error."
             test_h2o_atomic_fb = .false.
@@ -140,10 +140,10 @@ contains
         procedure(update_orbs_type), pointer :: update_orbs_funptr
         procedure(obj_func_type), pointer :: obj_func_funptr
         procedure(hess_x_type), pointer :: hess_x_funptr
-        integer(ip) :: ios
+        integer(ip) :: ios, error
         real(rp), allocatable :: kappa(:), grad(:), h_diag(:)
         real(rp) :: func
-        logical :: stable, error
+        logical :: stable
 
         ! assume tests pass
         test_h2o_saddle_fb = .true.
@@ -188,7 +188,7 @@ contains
         call solver(update_orbs_funptr, obj_func_funptr, n_param, error)
 
         ! check if error has occured
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_h2o_saddle_fb failed: Solver subroutine "// &
                 "produced error."
             test_h2o_saddle_fb = .false.
@@ -200,7 +200,7 @@ contains
         call update_orbs(kappa, func, grad, h_diag, hess_x_funptr, error)
 
         ! check if error has occured
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_h2o_saddle_fb failed: Orbital update "// &
             "subroutine produced error."
             test_h2o_saddle_fb = .false.
@@ -210,7 +210,7 @@ contains
         call stability_check(h_diag, hess_x_funptr, stable, kappa, error)
 
         ! check if error has occured
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_h2o_saddle_fb failed: Stability check "// &
             "subroutine produced error."
             test_h2o_saddle_fb = .false.
@@ -241,14 +241,14 @@ contains
         ! function
         !
         real(rp), intent(in) :: kappa(:)
-        logical, intent(out) :: error
+        integer(ip), intent(out) :: error
 
         real(rp), dimension(n_mo, n_mo) :: kappa_full, u
         real(rp) :: mo_coeff_tmp(n_ao, n_mo)
         integer(ip) :: xyz, i, j, idx
 
         ! initialize error flag
-        error = .false.
+        error = 0
 
         ! unpack orbital rotation
         kappa_full = 0.0
@@ -292,13 +292,13 @@ contains
         real(rp), intent(in) :: kappa(:)
         real(rp), intent(out) :: func, grad(:), h_diag(:)
         procedure(hess_x_type), intent(out), pointer :: hess_x_funptr
-        logical, intent(out) :: error
+        integer(ip), intent(out) :: error
 
         integer(ip) :: xyz, i, j, idx
         real(rp), dimension(n_mo, n_mo) :: kappa_full, u, h_diag_tmp, tmp1
 
         ! initialize error flag
-        error = .false.
+        error = 0
 
         ! unpack orbital rotation
         kappa_full = 0.0
@@ -381,7 +381,7 @@ contains
         ! otherwise go out of scope when that subroutine returns
         !
         real(rp), intent(in) :: x(:)
-        logical, intent(out) :: error
+        integer(ip), intent(out) :: error
         real(rp) :: hess_x(n_param)
 
         real(rp) :: x_full(n_mo, n_mo), hess_x_full(n_mo, n_mo), tmp2(3, n_mo), &
@@ -389,7 +389,7 @@ contains
         integer(ip) :: xyz1, i1, j1, idx1
 
         ! initialize error flag
-        error = .false.
+        error = 0
 
         ! unpack trial vector
         x_full = 0.0

--- a/tests/opentrustregion_unit_tests.f90
+++ b/tests/opentrustregion_unit_tests.f90
@@ -2060,4 +2060,35 @@ contains
 
     end function test_truncated_conjugate_gradient
 
+    logical(c_bool) function test_add_error_origin() bind(C)
+        !
+        ! this function tests the subroutine that adds the error origin to an error 
+        ! code
+        !
+        use opentrustregion, only: add_error_origin
+
+        integer(ip) :: error
+
+        ! assume tests pass
+        test_add_error_origin = .true.
+
+        ! check if subroutine adds error origin correctly if no origin is present
+        error = 1
+        call add_error_origin(error, 100)
+        if (error /= 101) then
+            write (stderr, *) "test_add_error_origin failed: Error origin not "// &
+                "correctly added."
+            test_add_error_origin = .false.
+        end if
+
+        ! check if subroutine skips adding error origin if origin is already present
+        call add_error_origin(error, 100)
+        if (error /= 101) then
+            write (stderr, *) "test_add_error_origin failed: Error code modified "// &
+                "even though error origin is already present."
+            test_add_error_origin = .false.
+        end if
+
+    end function test_add_error_origin
+
 end module opentrustregion_unit_tests

--- a/tests/opentrustregion_unit_tests.f90
+++ b/tests/opentrustregion_unit_tests.f90
@@ -110,7 +110,7 @@ contains
 
     function hartmann6d_hess_x(x)
         !
-        ! this function defiones the Hessian linear transformation operation for the
+        ! this function defines the Hessian linear transformation operation for the
         ! Hartmann 6D function
         !
         real(rp), intent(in) :: x(:)

--- a/tests/opentrustregion_unit_tests.f90
+++ b/tests/opentrustregion_unit_tests.f90
@@ -127,12 +127,12 @@ contains
         ! Hartmann 6D function
         !
         real(rp), intent(in) :: x(:)
-        logical, intent(out) :: error
+        integer(ip), intent(out) :: error
 
         real(rp) :: hess_x(size(x))
 
         ! initialize error flag
-        error = .false.
+        error = 0
 
         hess_x = hartmann6d_hess_x(x)
 
@@ -144,12 +144,12 @@ contains
         ! 6D function
         !
         real(rp), intent(in) :: delta_vars(:)
-        logical, intent(out) :: error
+        integer(ip), intent(out) :: error
 
         real(rp) :: func
 
         ! initialize error flag
-        error = .false.
+        error = 0
 
         func = hartmann6d_func(curr_vars + delta_vars)
 
@@ -165,12 +165,12 @@ contains
         real(rp), intent(in) :: delta_vars(:)
         real(rp), intent(out) :: func, grad(:), h_diag(:)
         procedure(hess_x_type), intent(out), pointer :: hess_x_funptr
-        logical, intent(out) :: error
+        integer(ip), intent(out) :: error
 
         integer(ip) :: i
 
         ! initialize error flag
-        error = .false.
+        error = 0
 
         ! update variables
         curr_vars = curr_vars + delta_vars
@@ -214,7 +214,7 @@ contains
                                    solver_conv_tol_default
 
         integer(ip), parameter :: n_param = 6
-        logical :: error
+        integer(ip) :: error
         real(rp) :: final_grad(n_param)
         procedure(update_orbs_type), pointer :: update_orbs_funptr
         procedure(obj_func_type), pointer :: obj_func_funptr
@@ -230,7 +230,7 @@ contains
         ! run solver, check if error has occured and check whether gradient is zero and 
         ! agrees with correct minimum
         call solver(update_orbs_funptr, obj_func_funptr, n_param, error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_solver failed: Produced error."
             test_solver = .false.
         end if
@@ -254,7 +254,7 @@ contains
         ! run solver, check if error has occured and check whether gradient is zero and 
         ! agrees with correct minimum
         call solver(update_orbs_funptr, obj_func_funptr, n_param, error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_solver failed: Produced error."
             test_solver = .false.
         end if
@@ -279,7 +279,7 @@ contains
         ! run solver, check if error has occured and check whether gradient is zero and 
         ! agrees with correct minimum
         call solver(update_orbs_funptr, obj_func_funptr, n_param, error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_solver failed: Produced error."
             test_solver = .false.
         end if
@@ -306,8 +306,8 @@ contains
 
         real(rp) :: vars(6), h_diag(6), direction(6)
         procedure(hess_x_type), pointer :: hess_x_funptr
-        logical :: stable, error
-        integer(ip) :: i
+        logical :: stable
+        integer(ip) :: error, i
 
         ! assume tests pass
         test_stability_check = .true.
@@ -322,7 +322,7 @@ contains
         ! run stability, check if error has occured check and determine whether minimum 
         ! is stable and the returned direction vanishes
         call stability_check(h_diag, hess_x_funptr, stable, direction, error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_stability_check failed: Produced error."
             test_stability_check = .false.
         end if
@@ -347,7 +347,7 @@ contains
         ! run stability check, check if error has occured and determine whether saddle 
         ! point is unstable and the returned direction is correct
         call stability_check(h_diag, hess_x_funptr, stable, direction, error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_stability_check failed: Produced error."
             test_stability_check = .false.
         end if
@@ -377,8 +377,7 @@ contains
         type(settings_type) :: settings
         real(rp) :: red_space_basis(6, 3), vars(6), grad(6), grad_norm, &
                     aug_hess(4, 4), solution(6), red_space_solution(3)
-        integer(ip) :: i, j
-        logical :: error
+        integer(ip) :: i, j, error
 
         ! assume tests pass
         test_newton_step = .true.
@@ -413,7 +412,7 @@ contains
         ! resulting solution is correct in reduced and full space
         call newton_step(aug_hess, grad_norm, red_space_basis, solution, &
                          red_space_solution, settings, error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_newton_step failed: Produced error."
             test_newton_step = .false.
         end if
@@ -441,8 +440,8 @@ contains
         type(settings_type) :: settings
         real(rp) :: red_space_basis(6, 3), vars(6), grad(6), grad_norm, &
                     aug_hess(4, 4), solution(6), red_space_solution(3), trust_radius, mu
-        integer(ip) :: i, j
-        logical :: bracketed, error
+        integer(ip) :: i, j, error
+        logical :: bracketed
 
         ! assume tests pass
         test_bisection = .true.
@@ -480,7 +479,7 @@ contains
         ! reduced and full space and respects target trust radius
         call bisection(aug_hess, grad_norm, red_space_basis, trust_radius, solution, &
                        red_space_solution, mu, bracketed, settings, error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_bisection failed: Produced error."
             test_bisection = .false.
         end if
@@ -525,7 +524,7 @@ contains
         ! minimum is closer than target trust radius and no level shift is necessary
         call bisection(aug_hess, grad_norm, red_space_basis, trust_radius, solution, &
                        red_space_solution, mu, bracketed, settings, error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_bisection failed: Produced error."
             test_bisection = .false.
         end if
@@ -546,7 +545,7 @@ contains
         type(settings_type) :: settings
         procedure(obj_func_type), pointer :: obj_func_funptr
         real(rp) :: vars(6), lower, upper, n
-        logical :: error
+        integer(ip) :: error
 
         ! assume tests pass
         test_bracket = .true.
@@ -567,7 +566,7 @@ contains
         ! perform bracket and determine if new point decreases objective function in
         ! comparison to lower and upper bound
         n = bracket(obj_func_funptr, vars, lower, upper, settings, error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_bracket failed: Produced error."
             test_bracket = .false.
         end if
@@ -580,7 +579,7 @@ contains
 
         ! try different order
         n = bracket(obj_func_funptr, vars, upper, lower, settings, error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_bracket failed: Produced error."
             test_bracket = .false.
         end if
@@ -685,7 +684,7 @@ contains
         type(settings_type) :: settings
         real(rp) :: matrix(3, 3)
         real(rp) :: eigval, eigvec(3)
-        logical :: error
+        integer(ip) :: error
 
         ! assume tests pass
         test_symm_mat_min_eig = .true.
@@ -701,7 +700,7 @@ contains
         ! call routine and determine if lowest eigenvalue and corresponding eigenvector
         ! are found
         call symm_mat_min_eig(matrix, eigval, eigvec, settings, error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_symm_mat_min_eig failed: Produced error."
             test_symm_mat_min_eig = .false.
         end if
@@ -727,7 +726,7 @@ contains
 
         type(settings_type) :: settings
         real(rp) :: matrix(3, 3), matrix_min_eigval
-        logical :: error
+        integer(ip) :: error
 
         ! assume tests pass
         test_min_eigval = .true.
@@ -742,7 +741,7 @@ contains
 
         ! call function and determine if lowest eigenvalue is found
         matrix_min_eigval = min_eigval(matrix, settings, error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_min_eigval failed: Produced error."
             test_min_eigval = .false.
         end if
@@ -815,8 +814,7 @@ contains
         type(settings_type) :: settings
         real(rp), allocatable :: red_space_basis(:, :)
         real(rp) :: grad(4), h_diag(4), grad_norm
-        logical :: error
-        integer(ip) :: i, j
+        integer(ip) :: error, i, j
 
         ! assume tests pass
         test_generate_trial_vectors = .true.
@@ -836,7 +834,7 @@ contains
         ! number of orthonormal trial vectors
         red_space_basis = generate_trial_vectors(grad, grad_norm, h_diag, settings, &
                                                  error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_generate_trial_vectors failed: Produced error."
             test_generate_trial_vectors = .false.
         end if
@@ -873,7 +871,7 @@ contains
         ! number of orthonormal trial vectors
         red_space_basis = generate_trial_vectors(grad, grad_norm, h_diag, settings, &
                                                  error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_generate_trial_vectors failed: Produced error."
             test_generate_trial_vectors = .false.
         end if
@@ -914,8 +912,7 @@ contains
 
         type(settings_type) :: settings
         real(rp), allocatable :: red_space_basis(:, :)
-        logical :: error
-        integer(ip) :: i, j
+        integer(ip) :: error, i, j
 
         ! assume tests pass
         test_generate_random_trial_vectors = .true.
@@ -932,7 +929,7 @@ contains
         ! generate trial vectors and determine whether function returns orthonormal 
         ! trial vectors
         call generate_random_trial_vectors(red_space_basis, settings, error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_generate_trial_vectors failed: Produced error."
             test_generate_random_trial_vectors = .false.
         end if
@@ -965,7 +962,7 @@ contains
         real(rp), dimension(2) :: vector_small
         real(rp) :: space(4, 2), symm_matrix(4, 4), lin_trans_space(4, 2), &
                     space_small(2, 2)
-        logical :: error
+        integer(ip) :: error
         character(100) :: line
 
         ! assume tests pass
@@ -982,7 +979,7 @@ contains
         ! perform Gram-Schmidt orthogonalization and determine whether added vector is
         ! orthonormalized
         call gram_schmidt(vector, space, settings, error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_gram_schmidt failed: Produced error."
             test_gram_schmidt = .false.
         end if
@@ -1014,7 +1011,7 @@ contains
         ! orthonormalized and linear transformation is correct
         call gram_schmidt(vector, space, settings, error, lin_trans_vector, &
                           lin_trans_space)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_gram_schmidt failed: Produced error."
             test_gram_schmidt = .false.
         end if
@@ -1039,7 +1036,7 @@ contains
         ! perform Gram-Schmidt orthogonalization and determine if function correctly
         ! throws error
         call gram_schmidt(vector, space, settings, error)
-        if ((.not. error) .or. (log_message /= " Vector passed to Gram-Schmidt "// &
+        if ((error == 0) .or. (log_message /= " Vector passed to Gram-Schmidt "// &
                                 "procedure is numerically zero.")) then
             write (stderr, *) "test_gram_schmidt failed: No error returned during "// &
                 "orthogonalization for zero vector."
@@ -1054,7 +1051,7 @@ contains
         ! perform Gram-Schmidt orthogonalization and determine if function correctly
         ! throws error
         call gram_schmidt(vector_small, space_small, settings, error)
-        if (.not. error .or. (log_message /= " Number of vectors in Gram-Schmidt "// &
+        if (error == 0 .or. (log_message /= " Number of vectors in Gram-Schmidt "// &
                               "procedure larger than dimension of vector space.")) then
             write (stderr, *) "test_gram_schmidt failed: No error returned during "// &
                 "orthogonalization when number of vectors is larger than dimension "// &
@@ -1351,7 +1348,7 @@ contains
 
         procedure(hess_x_type), pointer :: hess_x_funptr
         real(rp), dimension(6) :: vars, vector, solution, corr_vector, hess_vector
-        logical :: error
+        integer(ip) :: error
 
         ! assume tests pass
         test_jacobi_davidson_correction = .true.
@@ -1371,7 +1368,7 @@ contains
         ! calculate Jacobi-Davidson correction and compare values
         call jacobi_davidson_correction(hess_x_funptr, vector, solution, 0.5d0, &
                                         corr_vector, hess_vector, error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_jacobi_davidson_correction failed: Returned error."
             test_jacobi_davidson_correction = .false.
         end if
@@ -1402,7 +1399,7 @@ contains
         procedure(hess_x_type), pointer :: hess_x_funptr
         real(rp), dimension(6) :: vars, rhs, solution, vector, hess_vector, corr_vector
         real(rp) :: mu
-        logical :: error
+        integer(ip) :: error
 
         ! assume tests pass
         test_minres = .true.
@@ -1437,6 +1434,10 @@ contains
         ! transformation of the vector itself
         call minres(-rhs, hess_x_funptr, solution, mu, 1d-14, vector, hess_vector, &
                     settings, error)
+        if (error /= 0) then
+            write (stderr, *) "test_minres failed: Returned error."
+            test_minres = .false.
+        end if
         corr_vector = vector - dot_product(vector, solution) * solution
         corr_vector = hartmann6d_hess_x(corr_vector) - mu * corr_vector
         corr_vector = corr_vector - dot_product(corr_vector, solution) * solution
@@ -1457,6 +1458,10 @@ contains
         rhs = 0.d0
         call minres(-rhs, hess_x_funptr, solution, mu, 1d-14, vector, hess_vector, &
                     settings, error)
+        if (error /= 0) then
+            write (stderr, *) "test_minres failed: Returned error."
+            test_minres = .false.
+        end if
         if (sum(abs(vector)) > tol) then
             write (stderr, *) "test_minres failed: Returned solution is not zero "// &
                 "for a vanishing rhs."
@@ -1697,7 +1702,7 @@ contains
 
         type(solver_settings_type) :: settings
         real(rp) :: grad(3)
-        logical :: error
+        integer(ip) :: error
 
         ! assume tests pass
         test_sanity_check = .true.
@@ -1710,7 +1715,7 @@ contains
         settings%davidson = .true.
         settings%n_random_trial_vectors = 0
         call sanity_check(settings, 3, grad, error)
-        if (error) then
+        if (error /= 0) then
             write(stderr, *) "test_sanity_check failed: Error thrown for "// &
                 "non-negative and non-vanishing number of parameters."
             test_sanity_check = .false.
@@ -1718,7 +1723,7 @@ contains
 
         ! check if error is correctly thrown for vanishing number of parameters
         call sanity_check(settings, 0, grad, error)
-        if (.not. error) then
+        if (error == 0) then
             write(stderr, *) "test_sanity_check failed: Error not thrown for "// &
                 "vanishing number of parameters."
             test_sanity_check = .false.
@@ -1726,7 +1731,7 @@ contains
 
         ! check if error is correctly thrown for negative number of parameters
         call sanity_check(settings, -1, grad, error)
-        if (.not. error) then
+        if (error == 0) then
             write(stderr, *) "test_sanity_check failed: Error not thrown for "// &
                 "negative number of parameters."
             test_sanity_check = .false.
@@ -1743,13 +1748,13 @@ contains
 
         ! check if gradient size is treated correctly
         call sanity_check(settings, 3, grad, error)
-        if (error) then
+        if (error /= 0) then
             write(stderr, *) "test_sanity_check failed: Error thrown for correct "// &
                 "gradient size."
             test_sanity_check = .false.
         end if
         call sanity_check(settings, 4, grad, error)
-        if (.not. error) then
+        if (error == 0) then
             write(stderr, *) "test_sanity_check failed: Error not thrown for "// &
                 "incorrect gradient size."
             test_sanity_check = .false.
@@ -1771,12 +1776,12 @@ contains
         integer(ip), parameter :: n_param = 6
         real(rp) :: func, grad_norm, trust_radius, mu, ratio, solution_norm
         real(rp), dimension(n_param) :: grad, h_diag, solution
-        integer(ip) :: i, imicro, imicro_jacobi_davidson
+        integer(ip) :: i, imicro, imicro_jacobi_davidson, error
         procedure(obj_func_type), pointer :: obj_func_funptr
         procedure(hess_x_type), pointer :: hess_x_funptr
         procedure(precond_type), pointer :: precond_funptr
         type(solver_settings_type) :: settings
-        logical :: jacobi_davidson_started, max_precision_reached, error
+        logical :: jacobi_davidson_started, max_precision_reached
 
         ! assume tests pass
         test_level_shifted_davidson = .true.
@@ -1812,7 +1817,7 @@ contains
                                     mu, imicro, imicro_jacobi_davidson, &
                                     jacobi_davidson_started, max_precision_reached, &
                                     error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_level_shifted_davidson failed: Produced error "// &
                 "near minimum."
             test_level_shifted_davidson = .false.
@@ -1860,7 +1865,7 @@ contains
                                     mu, imicro, imicro_jacobi_davidson, &
                                     jacobi_davidson_started, max_precision_reached, &
                                     error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_level_shifted_davidson failed: Produced error "// &
                 "near saddle point."
             test_level_shifted_davidson = .false.
@@ -1905,7 +1910,7 @@ contains
                                     mu, imicro, imicro_jacobi_davidson, &
                                     jacobi_davidson_started, max_precision_reached, &
                                     error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_level_shifted_davidson failed: Produced error "// &
                 "near saddle point with Jacobi-Davidson solver."
             test_level_shifted_davidson = .false.
@@ -1955,12 +1960,12 @@ contains
         integer(ip), parameter :: n_param = 6
         real(rp) :: func, trust_radius, ratio, solution_norm
         real(rp), dimension(n_param) :: grad, h_diag, solution
-        integer(ip) :: i, imicro
+        integer(ip) :: i, imicro, error
         procedure(obj_func_type), pointer :: obj_func_funptr
         procedure(hess_x_type), pointer :: hess_x_funptr
         procedure(precond_type), pointer :: precond_funptr
         type(solver_settings_type) :: settings
-        logical :: max_precision_reached, error
+        logical :: max_precision_reached
 
         ! assume tests pass
         test_truncated_conjugate_gradient = .true.
@@ -1988,7 +1993,7 @@ contains
                                           precond_funptr, settings, trust_radius, &
                                           solution, imicro, max_precision_reached, &
                                           error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_truncated_jacobi_davidson failed: Produced "// &
                 "error near minimum."
             test_truncated_conjugate_gradient = .false.
@@ -2027,7 +2032,7 @@ contains
                                           precond_funptr, settings, trust_radius, &
                                           solution, imicro, max_precision_reached, &
                                           error)
-        if (error) then
+        if (error /= 0) then
             write (stderr, *) "test_truncated_jacobi_davidson failed: Produced "// &
                 "error near saddle point."
             test_truncated_conjugate_gradient = .false.

--- a/tests/opentrustregion_unit_tests.f90
+++ b/tests/opentrustregion_unit_tests.f90
@@ -1346,12 +1346,16 @@ contains
         !
         use opentrustregion, only: hess_x_type, jacobi_davidson_correction
 
+        type(settings_type) :: settings
         procedure(hess_x_type), pointer :: hess_x_funptr
         real(rp), dimension(6) :: vars, vector, solution, corr_vector, hess_vector
         integer(ip) :: error
 
         ! assume tests pass
         test_jacobi_davidson_correction = .true.
+
+        ! setup settings object
+        call setup_settings(settings)
 
         ! define point near saddle point, define trial vector, and solution to be 
         ! projected out
@@ -1367,7 +1371,7 @@ contains
 
         ! calculate Jacobi-Davidson correction and compare values
         call jacobi_davidson_correction(hess_x_funptr, vector, solution, 0.5d0, &
-                                        corr_vector, hess_vector, error)
+                                        corr_vector, hess_vector, settings, error)
         if (error /= 0) then
             write (stderr, *) "test_jacobi_davidson_correction failed: Returned error."
             test_jacobi_davidson_correction = .false.
@@ -2067,14 +2071,18 @@ contains
         !
         use opentrustregion, only: add_error_origin
 
+        type(settings_type) :: settings
         integer(ip) :: error
 
         ! assume tests pass
         test_add_error_origin = .true.
 
+        ! setup settings object
+        call setup_settings(settings)
+
         ! check if subroutine adds error origin correctly if no origin is present
         error = 1
-        call add_error_origin(error, 100)
+        call add_error_origin(error, 100, settings)
         if (error /= 101) then
             write (stderr, *) "test_add_error_origin failed: Error origin not "// &
                 "correctly added."
@@ -2082,10 +2090,28 @@ contains
         end if
 
         ! check if subroutine skips adding error origin if origin is already present
-        call add_error_origin(error, 100)
+        call add_error_origin(error, 100, settings)
         if (error /= 101) then
             write (stderr, *) "test_add_error_origin failed: Error code modified "// &
                 "even though error origin is already present."
+            test_add_error_origin = .false.
+        end if
+
+        ! check if subroutine does not modify error code when no error is encountered
+        error = 0
+        call add_error_origin(error, 100, settings)
+        if (error /= 0) then
+            write (stderr, *) "test_add_error_origin failed: Error code modified "// &
+                "even though error code of zero was passed."
+            test_add_error_origin = .false.
+        end if
+
+        ! check if subroutine raises error for invalid error code
+        error = -1
+        call add_error_origin(error, 100, settings)
+        if (error /= 101) then
+            write (stderr, *) "test_add_error_origin failed: Error code not "// &
+                "correctly returned for invalid (negative) error code."
             test_add_error_origin = .false.
         end if
 


### PR DESCRIPTION
**Summary**

This PR refactors interfaces for callback and `solver` and `stability_check` functions to improve error handling and cross-language consistency.

**Changes**

- Callback functions can now return a integer error code to indicate error status.
- All C functions have been updated to return an integer error code while modifying output arguments in place (C-style).
- Python solver and stability check function names have been updated to match the naming conventions used in C and Fortran.

**Notes**

- Python wrappers and associated logic have been updated to reflect these interface changes.
- No changes to the core solver behavior - only to function signatures and naming conventions.