### PR TITLE
Add support for projection functions in non-redundant optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ solver(update_orbs, obj_func, n_param, settings)
 The optimization process can be fine-tuned using the following settings:
 
 - **`precond`** (subroutine): Applies a preconditioner to a residual vector. Writes the result in-place into a provided array and returns an integer error code (0 for success, positive integers < 100 for errors).
+- **`project`** (subroutine): Applies a projection in-place to a provided vector and returns an integer error code (0 for success, positive integers < 100 for errors). Required for optimization using non-redundant parameters. When this is used, all other passed routines (`update_orbs`, `hess_x`, and `precond`) must be self-projecting.
 - **`conv_check`** (function): Returns whether the optimization has converged due to some supplied convergence criterion. Additionally, outputs an integer code indicating the success or failure of the function, positive integers less than 100 represent error conditions.
 - **`stability`** (boolean): Determines whether a stability check is performed upon convergence.
 - **`line_search`** (boolean): Determines whether a line search is performed after every macro iteration.
@@ -305,6 +306,7 @@ stable = stability_check(h_diag, hess_x, n_param, settings, kappa=kappa)
 The stability check can be fine-tuned using the following settings:
 
 - **`precond`** (subroutine): Applies a preconditioner to a residual vector. Writes the result in-place into a provided array and returns an integer error code (0 for success, positive integers < 100 for errors).
+- **`project`** (subroutine): Applies a projection in-place to a provided vector and returns an integer error code (0 for success, positive integers < 100 for errors). Required for stability check using non-redundant parameters. When this is used, all other passed routines (`hess_x` and `precond`) must be self-projecting.
 - **`diag_solver`** (string): Specifies which diagonalization solver to use. Options include:
   - `"davidson"`: standard Davidson method,
   - `"jacobi-davidson"`: Davidson method with fallback to Jacobi-Davidson if convergence is difficult, or automatically after `jacobi_davidson_start` micro iterations.
@@ -340,6 +342,7 @@ The library uses structured integer return codes to indicate whether a function 
 | `13`               | `hess_x`            |
 | `14`               | `precond`           |
 | `15`               | `conv_check`        |
+| `16`               | `project`           |
 
 ### Error Codes (`EE`)
 

--- a/pyopentrustregion/python_interface.py
+++ b/pyopentrustregion/python_interface.py
@@ -121,6 +121,7 @@ obj_func_interface_type = CFUNCTYPE(c_int, POINTER(c_real), POINTER(c_real))
 precond_interface_type = CFUNCTYPE(
     c_int, POINTER(c_real), POINTER(c_real), POINTER(c_real)
 )
+project_interface_type = CFUNCTYPE(c_int, POINTER(c_real))
 conv_check_interface_type = CFUNCTYPE(c_int, POINTER(c_bool))
 logger_interface_type = CFUNCTYPE(None, c_char_p)
 
@@ -188,6 +189,34 @@ def precond_interface_factory(
     return precond_interface
 
 
+def project_interface_factory(
+    project: Optional[Callable[[np.ndarray], None]], n_param: int
+) -> Any:
+    """
+    this function is a factory for the projection interface
+    """
+    if project is None:
+        return None
+
+    @project_interface_type
+    def project_interface(vector_ptr):
+        """
+        this function interfaces the projection function
+        """
+        # convert pointers to numpy array and float
+        vector = np.ctypeslib.as_array(vector_ptr, shape=(n_param,))
+
+        # call projection function
+        try:
+            project(vector)
+        except RuntimeError:
+            return 1
+
+        return 0
+
+    return project_interface
+
+
 def conv_check_interface_factory(conv_check: Optional[Callable[[], bool]]) -> Any:
     """
     this function is a factory for the convergence check interface
@@ -233,6 +262,7 @@ def logger_interface_factory(logger: Optional[Callable[[str], None]]) -> Any:
 class SolverSettingsC(Structure):
     _fields_ = [
         ("precond", c_void_p),
+        ("project", c_void_p),
         ("conv_check", c_void_p),
         ("logger", c_void_p),
         ("stability", c_bool),
@@ -255,6 +285,7 @@ class SolverSettingsC(Structure):
 class StabilitySettingsC(Structure):
     _fields_ = [
         ("precond", c_void_p),
+        ("project", c_void_p),
         ("logger", c_void_p),
         ("initialized", c_bool),
         ("conv_tol", c_real),
@@ -309,9 +340,11 @@ class SolverSettings(Settings):
     init_c_struct = lib.init_solver_settings
 
     precond: Optional[Callable[[np.ndarray, float, np.ndarray], None]]
+    project: Optional[Callable[[np.ndarray], None]]
     conv_check: Optional[Callable[[], bool]]
     logger: Optional[Callable[[str], None]]
     precond_interface: Any
+    project_interface: Any
     conv_check_interface: Any
     logger_interface: Any
 
@@ -322,8 +355,10 @@ class StabilitySettings(Settings):
     init_c_struct = lib.init_stability_settings
 
     precond: Optional[Callable[[np.ndarray, float, np.ndarray], None]]
+    project: Optional[Callable[[np.ndarray], None]]
     logger: Optional[Callable[[str], None]]
     precond_interface: Any
+    project_interface: Any
     logger_interface: Any
 
 
@@ -450,6 +485,9 @@ def solver(
         "precond", precond_interface_factory(settings.precond, n_param)
     )
     settings.set_optional_callback(
+        "project", project_interface_factory(settings.project, n_param)
+    )
+    settings.set_optional_callback(
         "conv_check", conv_check_interface_factory(settings.conv_check)
     )
     settings.set_optional_callback("logger", logger_interface_factory(settings.logger))
@@ -487,6 +525,9 @@ def stability_check(
     # settings is set (e.g. n_param)
     settings.set_optional_callback(
         "precond", precond_interface_factory(settings.precond, n_param)
+    )
+    settings.set_optional_callback(
+        "project", project_interface_factory(settings.project, n_param)
     )
     settings.set_optional_callback("logger", logger_interface_factory(settings.logger))
 

--- a/pyopentrustregion/testsuite.py
+++ b/pyopentrustregion/testsuite.py
@@ -141,6 +141,7 @@ fortran_tests = {
         "logger_f_wrapper",
         "obj_func_f_wrapper",
         "precond_f_wrapper",
+        "project_f_wrapper",
         "solver_c_wrapper",
         "stability_check_c_wrapper",
         "update_orbs_f_wrapper",
@@ -296,6 +297,12 @@ class PyInterfaceTests(unittest.TestCase):
             """
             precond_residual[:] = mu * residual
 
+        def mock_project(vector):
+            """
+            this function is a mock function for the projection function
+            """
+            vector[:] = 2 * vector
+
         def mock_conv_check():
             """
             this function is a mock function for the convergence check function
@@ -314,6 +321,7 @@ class PyInterfaceTests(unittest.TestCase):
         # initialize settings object
         settings = SolverSettings()
         settings.precond = mock_precond
+        settings.project = mock_project
         settings.conv_check = mock_conv_check
         settings.logger = mock_logger
         for field_info in settings.c_struct._fields_:
@@ -359,6 +367,12 @@ class PyInterfaceTests(unittest.TestCase):
             """
             precond_residual[:] = mu * residual
 
+        def mock_project(vector):
+            """
+            this function is a mock function for the projection function
+            """
+            vector[:] = 2 * vector
+
         def mock_logger(message):
             """
             this function is a mock function for the logging function
@@ -371,6 +385,7 @@ class PyInterfaceTests(unittest.TestCase):
         # initialize settings object
         settings = StabilitySettings()
         settings.precond = mock_precond
+        settings.project = mock_project
         settings.logger = mock_logger
         for field_info in settings.c_struct._fields_:
             field_name, field_type = field_info[:2]

--- a/src/opentrustregion.f90
+++ b/src/opentrustregion.f90
@@ -32,7 +32,7 @@ module opentrustregion
     integer(ip), parameter :: error_solver = 100, error_stability_check = 200, &
                               error_obj_func = 1100, error_update_orbs = 1200, &
                               error_hess_x = 1300, error_precond = 1400, &
-                              error_conv_check = 1500
+                              error_conv_check = 1500, error_project = 1600
 
     ! define useful parameters
     real(rp), parameter :: numerical_zero = 1e-14_rp, precond_floor = 1e-10_rp, &
@@ -42,6 +42,23 @@ module opentrustregion
     integer(ip), parameter :: verbosity_silent = 0, verbosity_error = 1, &
                               verbosity_warning = 2, verbosity_info = 3, &
                               verbosity_debug = 4
+
+    ! define log messages
+    character(len=*), parameter :: &
+        random_trial_vector_warning_msg = &
+            "Number of random trial vectors should be smaller than half the number "// &
+            "of parameters.", &
+        gram_schmidt_zero_vector_error_msg = &
+            "Vector passed to Gram-Schmidt procedure is numerically zero.", &
+        gram_schmidt_too_many_vectors_error_msg = &
+            "Number of vectors in Gram-Schmidt procedure larger than dimension of "// &
+            "vector space.", &
+        project_warning_msg = &
+            "Custom projection is provided. To optimize performance, OTR assumes "// &
+            "that all other provided routines (update_orbs, hess_x, precond) are "// &
+            "already projected onto the relevant orbital rotation subspace. If "// &
+            "these routines are not self-projecting, redundant rotations may "// &
+            "contaminate the trial space and cause convergence issues."
 
     ! interfaces for callback functions
     abstract interface
@@ -88,6 +105,15 @@ module opentrustregion
     end interface
 
     abstract interface
+        subroutine project_type(vector, error)
+            import :: rp, ip
+
+            real(rp), intent(inout), target :: vector(:)
+            integer(ip), intent(out) :: error
+        end subroutine project_type
+    end interface
+
+    abstract interface
         function conv_check_type(error) result(converged)
             import :: ip
 
@@ -108,6 +134,7 @@ module opentrustregion
         real(rp) :: conv_tol
         integer(ip) :: n_random_trial_vectors, jacobi_davidson_start, seed, verbose
         procedure(precond_type), pointer, nopass :: precond
+        procedure(project_type), pointer, nopass :: project
         procedure(logger_type), pointer, nopass :: logger
     contains
         procedure :: log => print_message
@@ -142,15 +169,16 @@ module opentrustregion
 
     ! default settings
     type(solver_settings_type), parameter :: default_solver_settings = &
-        solver_settings_type(precond = null(), conv_check = null(), logger = null(), &
-                             stability = .false., line_search = .false., &
-                             initialized = .true., conv_tol = 1e-5_rp, &
-                             start_trust_radius = 0.4_rp, global_red_factor = 1e-3_rp, &
-                             local_red_factor = 1e-4_rp, n_random_trial_vectors = 1, &
-                             n_macro = 150, n_micro = 50, jacobi_davidson_start = 30, &
-                             seed = 42, verbose = 0, subsystem_solver = "davidson")
+        solver_settings_type(precond = null(), project = null(), conv_check = null(), &
+                             logger = null(), stability = .false., &
+                             line_search = .false., initialized = .true., &
+                             conv_tol = 1e-5_rp, start_trust_radius = 0.4_rp, &
+                             global_red_factor = 1e-3_rp, local_red_factor = 1e-4_rp, &
+                             n_random_trial_vectors = 1, n_macro = 150, n_micro = 50, &
+                             jacobi_davidson_start = 30, seed = 42, verbose = 0, &
+                             subsystem_solver = "davidson")
     type(stability_settings_type), parameter :: default_stability_settings = &
-        stability_settings_type(precond = null(), logger = null(), &
+        stability_settings_type(precond = null(), project = null(), logger = null(), &
                                 initialized = .true., conv_tol = 1e-8_rp, &
                                 n_random_trial_vectors = 20, n_iter = 100, &
                                 jacobi_davidson_start = 50, seed = 42, verbose = 0, &
@@ -256,13 +284,9 @@ contains
                         settings%subsystem_solver == "jacobi-davidson") then
                         kappa_norm = dnrm2(n_param, kappa, 1_ip)
                     else
-                        if (associated(settings%precond)) then
-                            call settings%precond(kappa, 0.0_rp, precond_kappa, error)
-                            call add_error_origin(error, error_precond, settings)
-                            if (error /= 0) return
-                        else
-                            call abs_diag_precond(kappa, h_diag, precond_kappa)
-                        end if
+                        call abs_diag_precond(kappa, h_diag, precond_kappa, settings, &
+                                              error)
+                        if (error /= 0) return
                         kappa_norm = sqrt(ddot(n_param, kappa, 1_ip, precond_kappa, &
                                                1_ip))
                         mu = 0.0_rp
@@ -534,13 +558,9 @@ contains
             if (settings%diag_solver == "davidson" .or. iter <= &
                 settings%jacobi_davidson_start) then
                 ! precondition residual
-                if (associated(settings%precond)) then
-                    call settings%precond(residual, 0.0_rp, basis_vec, error)
-                    call add_error_origin(error, error_precond, settings)
-                    if (error /= 0) return
-                else
-                    call level_shifted_diag_precond(residual, 0.0_rp, h_diag, basis_vec)
-                end if
+                call level_shifted_diag_precond(residual, 0.0_rp, h_diag, basis_vec, &
+                                                settings, error)
+                if (error /= 0) return
 
                 ! orthonormalize to current orbital space to get new basis vector
                 call gram_schmidt(basis_vec, red_space_basis, settings, error)
@@ -1187,6 +1207,11 @@ contains
             red_space_basis(:, 1) = grad/grad_norm
             red_space_basis(:, 2) = 0.0_rp
             red_space_basis(min_idx, 2) = 1.0_rp
+            if (associated(settings%project)) then
+                call settings%project(red_space_basis(:, 2), error)
+                call add_error_origin(error, error_project, settings)
+                if (error /= 0) return
+            end if
             call gram_schmidt(red_space_basis(:, 2), &
                               reshape(red_space_basis(:, 1), &
                                       [size(red_space_basis, 1), 1]), &
@@ -1231,6 +1256,11 @@ contains
                 call random_number(red_space_basis(:, i))
                 red_space_basis(:, i) = 2*red_space_basis(:, i) - 1
             end do
+            if (associated(settings%project)) then
+                call settings%project(red_space_basis(:, i), error)
+                call add_error_origin(error, error_project, settings)
+                if (error /= 0) return
+            end if
             call gram_schmidt(red_space_basis(:, i), red_space_basis(:, :i - 1), &
                               settings, error)
             if (error /= 0) return
@@ -1270,13 +1300,13 @@ contains
         n_vectors = size(space, 2)
 
         if (dnrm2(n_param, vector, 1_ip) < zero_thres) then
-            call settings%log("Vector passed to Gram-Schmidt procedure is "// &
-                "numerically zero.", verbosity_error, .true.)
+            call settings%log(gram_schmidt_zero_vector_error_msg, verbosity_error, &
+                              .true.)
             error = 1
             return
         else if (n_vectors > n_param - 1) then
-            call settings%log("Number of vectors in Gram-Schmidt procedure larger "// &
-                "than dimension of vector space.", verbosity_error, .true.)
+            call settings%log(gram_schmidt_too_many_vectors_error_msg, &
+                              verbosity_error, .true.)
             error = 1
             return
         end if
@@ -1382,36 +1412,71 @@ contains
 
     end subroutine init_stability_settings
 
-    subroutine level_shifted_diag_precond(vector, mu, h_diag, precond_vector)
+    subroutine level_shifted_diag_precond(vector, mu, h_diag, precond_vector, &
+                                          settings, error)
         !
         ! this function defines the default level-shifted diagonal preconditioner
         !
         real(rp), intent(in) :: vector(:), mu, h_diag(:)
         real(rp), intent(out) :: precond_vector(:)
-        
-        ! construct level-shifted preconditioner
-        precond_vector = h_diag - mu
-        where (abs(precond_vector) < precond_floor)
-            precond_vector = precond_floor
-        end where
+        class(settings_type), intent(in) :: settings
+        integer(ip), intent(out) :: error
 
-        ! precondition vector
-        precond_vector = vector / precond_vector
+        ! initialize error flag
+        error = 0
+
+        ! check for user-defined preconditioner
+        if (associated(settings%precond)) then
+            call settings%precond(vector, mu, precond_vector, error)
+            call add_error_origin(error, error_precond, settings)
+            if (error /= 0) return
+        ! construct level-shifted preconditioner
+        else
+            precond_vector = h_diag - mu
+            where (abs(precond_vector) < precond_floor)
+                precond_vector = precond_floor
+            end where
+            precond_vector = vector / precond_vector
+
+            ! ensure basis vector stays in subspace
+            if (associated(settings%project)) then
+                call settings%project(precond_vector, error)
+                call add_error_origin(error, error_project, settings)
+                if (error /= 0) return
+            end if
+        end if
         
     end subroutine level_shifted_diag_precond
 
-    subroutine abs_diag_precond(vector, h_diag, precond_vector)
+    subroutine abs_diag_precond(vector, h_diag, precond_vector, settings, error)
         !
         ! this function defines the default absolute diagonal preconditioner
         !
         real(rp), intent(in) :: vector(:), h_diag(:)
         real(rp), intent(out) :: precond_vector(:)
+        class(settings_type), intent(in) :: settings
+        integer(ip), intent(out) :: error
 
+        ! initialize error flag
+        error = 0
+
+        ! check for user-defined preconditioner
+        if (associated(settings%precond)) then
+            call settings%precond(vector, 0.0_rp, precond_vector, error)
+            call add_error_origin(error, error_precond, settings)
+            if (error /= 0) return
         ! construct positive-definite preconditioner
-        precond_vector = max(abs(h_diag), precond_floor)
-        
-        ! precondition vector
-        precond_vector = vector / precond_vector
+        else
+            precond_vector = max(abs(h_diag), precond_floor)
+            precond_vector = vector / precond_vector
+
+            ! ensure basis vector stays in subspace
+            if (associated(settings%project)) then
+                call settings%project(precond_vector, error)
+                call add_error_origin(error, error_project, settings)
+                if (error /= 0) return
+            end if
+        end if
         
     end subroutine abs_diag_precond
 
@@ -1969,13 +2034,9 @@ contains
 
                 if (.not. jacobi_davidson_started) then
                     ! precondition residual
-                    if (associated(settings%precond)) then
-                        call settings%precond(residual, mu, basis_vec, error)
-                        call add_error_origin(error, error_precond, settings)
-                        if (error /= 0) return
-                    else
-                        call level_shifted_diag_precond(residual, mu, h_diag, basis_vec)
-                    end if
+                    call level_shifted_diag_precond(residual, mu, h_diag, basis_vec, &
+                                                    settings, error)
+                    if (error /= 0) return
 
                     ! orthonormalize to current orbital space to get new basis vector
                     call gram_schmidt(basis_vec, red_space_basis, settings, error)
@@ -2123,14 +2184,10 @@ contains
         ! get initial residual norm
         initial_residual_norm = dnrm2(n_param, residual, 1_ip)
 
-        ! initialize preconditioned residual and direction,
-        if (associated(settings%precond)) then
-            call settings%precond(residual, 0.0_rp, precond_residual, error)
-            call add_error_origin(error, error_precond, settings)
-            if (error /= 0) return
-        else
-            call abs_diag_precond(residual, h_diag, precond_residual)
-        end if
+        ! initialize preconditioned residual and direction
+        call abs_diag_precond(residual, h_diag, precond_residual, settings, error)
+        if (error /= 0) return
+
         direction = -precond_residual
 
         ! allocate arrays needed to propose a new step
@@ -2158,17 +2215,10 @@ contains
                              curvature
 
             ! precondition current solution and direction
-            if (associated(settings%precond)) then
-                call settings%precond(solution, 0.0_rp, precond_solution, error)
-                call add_error_origin(error, error_precond, settings)
-                if (error /= 0) return
-                call settings%precond(direction, 0.0_rp, precond_direction, error)
-                call add_error_origin(error, error_precond, settings)
-                if (error /= 0) return
-            else
-                call abs_diag_precond(solution, h_diag, precond_solution)
-                call abs_diag_precond(direction, h_diag, precond_direction)
-            end if
+            call abs_diag_precond(solution, h_diag, precond_solution, settings, error)
+            if (error /= 0) return
+            call abs_diag_precond(direction, h_diag, precond_direction, settings, error)
+            if (error /= 0) return
 
             ! calculate dot products
             solution_dot = ddot(n_param, solution, 1_ip, precond_solution, 1_ip)
@@ -2218,13 +2268,9 @@ contains
             
             ! get residual for model
             residual_new = residual + step_size * hess_direction
-            if (associated(settings%precond)) then
-                call settings%precond(residual_new, 0.0_rp, precond_residual_new, error)
-                call add_error_origin(error, error_precond, settings)
-                if (error /= 0) return
-            else
-                call abs_diag_precond(residual_new, h_diag, precond_residual_new)
-            end if
+            call abs_diag_precond(residual_new, h_diag, precond_residual_new, &
+                                  settings, error)
+            if (error /= 0) return
 
             ! check for linear or superlinear (in this case quadratic) convergence
             if (dnrm2(n_param, residual_new, 1_ip) <= initial_residual_norm * &
@@ -2269,24 +2315,18 @@ contains
                 if (accept_step .or. max_precision_reached) exit
 
                 ! check if step exceeds new trust region boundary
-                if (associated(settings%precond)) then
-                    call settings%precond(solution, 0.0_rp, precond_solution, error)
-                    if (error /= 0) return
-                else
-                    call abs_diag_precond(solution, h_diag, precond_solution)
-                end if
+                call abs_diag_precond(solution, h_diag, precond_solution, settings, &
+                                      error)
+                if (error /= 0) return
+
                 if (ddot(n_param, solution, 1_ip, precond_solution, 1_ip) > &
                     trust_radius ** 2) then
                     ! find step that exceeds trust region boundary
                     do i = 1, size(solutions, 2)
-                        if (associated(settings%precond)) then
-                            call settings%precond(solutions(:, i), 0.0_rp, &
-                                                  precond_solution, error)
-                            if (error /= 0) return
-                        else
-                            call abs_diag_precond(solutions(:, i), h_diag, &
-                                                  precond_solution)
-                        end if
+                        call abs_diag_precond(solutions(:, i), h_diag, &
+                                              precond_solution, settings, error)
+                        if (error /= 0) return
+
                         if (ddot(n_param, solutions(:, i), 1_ip, precond_solution, &
                                  1_ip) > trust_radius ** 2) then
                             ! get previous step
@@ -2298,21 +2338,12 @@ contains
                             hess_direction = h_solutions(:, i) - h_solutions(:, i - 1)
 
                             ! precondition current solution and direction
-                            if (associated(settings%precond)) then
-                                call settings%precond(solution, 0.0_rp, &
-                                                      precond_solution, error)
-                                call add_error_origin(error, error_precond, settings)
-                                if (error /= 0) return
-                                call settings%precond(direction, 0.0_rp, &
-                                                      precond_direction, error)
-                                call add_error_origin(error, error_precond, settings)
-                                if (error /= 0) return
-                            else
-                                call abs_diag_precond(solution, h_diag, &
-                                                      precond_solution)
-                                call abs_diag_precond(direction, h_diag, &
-                                                      precond_direction)
-                            end if
+                            call abs_diag_precond(solution, h_diag, precond_solution, &
+                                                  settings, error)
+                            if (error /= 0) return
+                            call abs_diag_precond(direction, h_diag, &
+                                                  precond_direction, settings, error)
+                            if (error /= 0) return
 
                             ! calculate dot products
                             solution_dot = ddot(n_param, solution, 1_ip, &
@@ -2440,8 +2471,7 @@ contains
              settings%subsystem_solver == "jacobi-davidson") .and. &
             settings%n_random_trial_vectors > n_param/2) then
             settings%n_random_trial_vectors = n_param/2
-            write (msg, '(A, I0, A)') "Number of random trial vectors should be "// &
-                "smaller than half the number of parameters. Setting to ", &
+            write (msg, '(A, I0, A)') random_trial_vector_warning_msg//" Setting to ", &
                 settings%n_random_trial_vectors, "."
             call settings%log(msg, verbosity_warning)
         end if
@@ -2466,6 +2496,10 @@ contains
             return
         end if
 
+        ! check whether projection functions is passed
+        if (associated(settings%project)) call settings%log(project_warning_msg, &
+                                                            verbosity_warning)
+
     end subroutine solver_sanity_check
 
     subroutine stability_sanity_check(settings, n_param, error)
@@ -2486,8 +2520,7 @@ contains
         ! check that number of random trial vectors is below number of parameters
         if (settings%n_random_trial_vectors > n_param/2) then
             settings%n_random_trial_vectors = n_param/2
-            write (msg, '(A, I0, A)') "Number of random trial vectors should be "// &
-                "smaller than half the number of parameters. Setting to ", &
+            write (msg, '(A, I0, A)') random_trial_vector_warning_msg//" Setting to ", &
                 settings%n_random_trial_vectors, "."
             call settings%log(msg, verbosity_warning)
         end if
@@ -2501,6 +2534,10 @@ contains
             error = 1
             return
         end if
+
+        ! check whether projection functions is passed
+        if (associated(settings%project)) call settings%log(project_warning_msg, &
+                                                            verbosity_warning)
 
     end subroutine stability_sanity_check
 

--- a/tests/c_interface_mock.f90
+++ b/tests/c_interface_mock.f90
@@ -38,10 +38,10 @@ contains
         !
         use c_interface, only: solver_settings_type_c, update_orbs_c_type, &
                                hess_x_c_type, obj_func_c_type, precond_c_type, &
-                               conv_check_c_type, logger_c_type
+                               project_c_type, conv_check_c_type, logger_c_type
         use test_reference, only: test_update_orbs_c_funptr, test_obj_func_c_funptr, &
-                                  test_precond_c_funptr, test_conv_check_c_funptr, &
-                                  operator(/=)
+                                  test_precond_c_funptr, test_project_c_funptr, &
+                                  test_conv_check_c_funptr, operator(/=)
 
         type(c_funptr), intent(in), value :: update_orbs_c_funptr, obj_func_c_funptr
         integer(c_ip), intent(in), value :: n_param_c
@@ -73,6 +73,11 @@ contains
             test_precond_c_funptr(settings_c%precond, "solver_py_interface", &
                                   " by given preconditioning function")
 
+        ! test passed projection function
+        test_solver_interface = test_solver_interface .and. &
+            test_project_c_funptr(settings_c%project, "solver_py_interface", &
+                                  " by given projection function")
+
         ! test passed convergence check function
         test_solver_interface = test_solver_interface .and. &
             test_conv_check_c_funptr(settings_c%conv_check, "solver_py_interface", &
@@ -103,9 +108,9 @@ contains
         ! subroutine
         !
         use c_interface, only: stability_settings_type_c, hess_x_c_type, &
-                               precond_c_type, logger_c_type
+                               precond_c_type, project_c_type, logger_c_type
         use test_reference, only: tol_c, test_hess_x_c_funptr, test_precond_c_funptr, &
-                                  operator(/=)
+                                  test_project_c_funptr, operator(/=)
 
         real(c_rp), intent(in), target :: h_diag_c(*)
         type(c_funptr), intent(in), value :: hess_x_c_funptr
@@ -142,6 +147,11 @@ contains
         test_stability_check_interface = test_stability_check_interface .and. &
             test_precond_c_funptr(settings_c%precond, "stability_check_py_interface", &
                                   " by given preconditioning function")
+
+        ! test passed projection function
+        test_stability_check_interface = test_stability_check_interface .and. &
+            test_project_c_funptr(settings_c%project, "stability_check_py_interface", &
+                                  " by given projection function")
 
         ! get Fortran pointer to passed logging function and call it
         message = "test" // c_null_char

--- a/tests/c_interface_unit_tests.f90
+++ b/tests/c_interface_unit_tests.f90
@@ -8,8 +8,8 @@ module c_interface_unit_tests
 
     use opentrustregion, only: rp, ip, stderr
     use c_interface, only: c_rp, c_ip, update_orbs_c_type, hess_x_c_type, &
-                           obj_func_c_type, precond_c_type, conv_check_c_type, &
-                           logger_c_type
+                           obj_func_c_type, precond_c_type, project_c_type, &
+                           conv_check_c_type, logger_c_type
     use test_reference, only: tol, tol_c, n_param, n_param_c
     use, intrinsic :: iso_c_binding, only: c_bool, c_ptr, c_loc, c_funptr, c_funloc, &
                                            c_char, c_associated, c_null_ptr, c_null_char
@@ -24,6 +24,7 @@ module c_interface_unit_tests
     procedure(hess_x_c_type), pointer :: mock_hess_x_ptr => mock_hess_x
     procedure(obj_func_c_type), pointer ::  mock_obj_func_ptr => mock_obj_func
     procedure(precond_c_type), pointer ::  mock_precond_ptr => mock_precond
+    procedure(project_c_type), pointer ::  mock_project_ptr => mock_project
     procedure(conv_check_c_type), pointer ::  mock_conv_check_ptr => mock_conv_check
     procedure(logger_c_type), pointer ::  mock_logger_ptr => mock_logger
 
@@ -94,6 +95,19 @@ contains
 
     end function mock_precond
 
+    function mock_project(vector) result(error) bind(C)
+        !
+        ! this function is a test function for the C projection function
+        !
+        real(c_rp), intent(inout), target :: vector(*)
+        integer(c_ip) :: error
+
+        vector(:n_param) = 2 * vector(:n_param)
+
+        error = 0
+
+    end function mock_project
+
     function mock_conv_check(converged) result(error) bind(C)
         !
         ! this function is a test function for the convergence check function
@@ -144,6 +158,7 @@ contains
         ! associate optional settings with values
         settings = ref_settings
         settings%precond = c_funloc(mock_precond)
+        settings%project = c_funloc(mock_project)
         settings%conv_check = c_funloc(mock_conv_check)
         settings%logger = c_funloc(mock_logger)
 
@@ -206,6 +221,7 @@ contains
         ! associate optional arguments with values
         settings = ref_settings
         settings%precond = c_funloc(mock_precond)
+        settings%project = c_funloc(mock_project)
         settings%logger = c_funloc(mock_logger)
 
         ! unassociate returned direction pointer
@@ -370,6 +386,28 @@ contains
 
     end function test_precond_f_wrapper
 
+    logical(c_bool) function test_project_f_wrapper() bind(C)
+        !
+        ! this function tests the Fortran wrapper for the projection function
+        !
+        use opentrustregion, only: project_type
+        use c_interface, only: project_before_wrapping, project_f_wrapper
+        use test_reference, only: test_project_funptr
+
+        procedure(project_type), pointer :: project_funptr
+
+        ! inject mock function
+        project_before_wrapping => mock_project
+
+        ! get pointer to subroutine
+        project_funptr => project_f_wrapper
+
+        ! test projection wrapper
+        test_project_f_wrapper = test_project_funptr(project_funptr, &
+                                                     "project_f_wrapper", "")
+
+    end function test_project_f_wrapper
+
     logical(c_bool) function test_conv_check_f_wrapper() bind(C)
         !
         ! this function tests the Fortran wrapper for the convergence check function
@@ -435,8 +473,8 @@ contains
         call init_solver_settings_c(settings)
 
         ! check function pointers
-        if (c_associated(settings%precond) .or. c_associated(settings%conv_check) .or. &
-            c_associated(settings%logger)) then
+        if (c_associated(settings%precond) .or. c_associated(settings%project) .or. &
+            c_associated(settings%conv_check) .or. c_associated(settings%logger)) then
             write (stderr, *) "test_init_solver_settings_c failed: Function "// &
                 "pointers should not be initialized."
             test_init_solver_settings_c = .false.
@@ -469,7 +507,8 @@ contains
         call init_stability_settings_c(settings)
 
         ! check function pointers
-        if (c_associated(settings%precond) .or. c_associated(settings%logger)) then
+        if (c_associated(settings%precond) .or. c_associated(settings%project) .or. &
+            c_associated(settings%logger)) then
             write (stderr, *) "test_init_stability_settings_c failed: Function "// &
                 "pointers should not be initialized."
             test_init_stability_settings_c = .false.
@@ -491,13 +530,12 @@ contains
         !
         use c_interface, only: solver_settings_type_c, assignment(=)
         use opentrustregion, only: solver_settings_type
-        use test_reference, only: assignment(=), ref_settings, operator(/=)
+        use test_reference, only: assignment(=), ref_settings, test_precond_funptr, &
+                                  test_project_funptr, test_conv_check_funptr, &
+                                  operator(/=)
 
         type(solver_settings_type_c) :: settings_c
         type(solver_settings_type) :: settings
-        real(rp), allocatable :: residual(:), precond_residual(:)
-        integer(ip) :: error
-        logical :: converged
 
         ! assume test passes
         test_assign_solver_f_c = .true.
@@ -505,6 +543,7 @@ contains
         ! initialize the C settings with custom values
         settings_c = ref_settings
         settings_c%precond = c_funloc(mock_precond)
+        settings_c%project = c_funloc(mock_project)
         settings_c%conv_check = c_funloc(mock_conv_check)
         settings_c%logger = c_funloc(mock_logger)
 
@@ -517,20 +556,20 @@ contains
             write (stderr, *) "test_assign_solver_f_c failed: Preconditioner "// &
                 "function not associated with value."
         else
-            allocate(residual(n_param), precond_residual(n_param))
-            residual = 1.0_rp
-            call settings%precond(residual, 5.0_rp, precond_residual, error)
-            if (error /= 0) then
-                test_assign_solver_f_c = .false.
-                write (stderr, *) "test_assign_solver_f_c failed: Preconditioner "// &
-                    "function produced error."
-            end if
-            if (any(abs(precond_residual - 5.0_rp) > tol)) then
-                test_assign_solver_f_c = .false.
-                write (stderr, *) "test_assign_solver_f_c failed: Returned "// &
-                    "preconditioner of preconditioner function wrong."
-            end if
-            deallocate(residual, precond_residual)
+            test_assign_solver_f_c = test_assign_solver_f_c .and. &
+                test_precond_funptr(settings%precond, "assign_solver_f_c", &
+                                    " by preconditioner function")
+        end if
+
+        ! check projection function
+        if (.not. associated(settings%project)) then
+            test_assign_solver_f_c = .false.
+            write (stderr, *) "test_assign_solver_f_c failed: Projection function "// &
+                "not associated with value."
+        else
+            test_assign_solver_f_c = test_assign_solver_f_c .and. &
+                test_project_funptr(settings%project, "assign_solver_f_c", &
+                                    " by projection function")
         end if
 
         ! check convergence check
@@ -539,17 +578,9 @@ contains
             write (stderr, *) "test_assign_solver_f_c failed: Convergence check "// &
                 "function not associated with value."
         else
-            converged = settings%conv_check(error)
-            if (error /= 0) then
-                test_assign_solver_f_c = .false.
-                write (stderr, *) "test_assign_solver_f_c failed: Convergence "// &
-                    "check function produced error."
-            end if
-            if (.not. converged) then
-                test_assign_solver_f_c = .false.
-                write (stderr, *) "test_assign_solver_f_c failed: Returned "// &
-                    "convergence logical of convergence check function wrong."
-            end if
+            test_assign_solver_f_c = test_assign_solver_f_c .and. &
+                test_conv_check_funptr(settings%conv_check, "assign_solver_f_c", &
+                                       " by convergence check function")
         end if
 
         ! check logging function
@@ -590,12 +621,11 @@ contains
         !
         use c_interface, only: stability_settings_type_c, assignment(=)
         use opentrustregion, only: stability_settings_type
-        use test_reference, only: assignment(=), ref_settings, operator(/=)
+        use test_reference, only: assignment(=), ref_settings, test_precond_funptr, &
+                                  test_project_funptr, operator(/=)
 
         type(stability_settings_type_c) :: settings_c
         type(stability_settings_type)   :: settings
-        real(rp), allocatable :: residual(:), precond_residual(:)
-        integer(ip) :: error
 
         ! assume test passes
         test_assign_stability_f_c = .true.
@@ -603,6 +633,7 @@ contains
         ! initialize the C settings with custom values
         settings_c = ref_settings
         settings_c%precond = c_funloc(mock_precond)
+        settings_c%project = c_funloc(mock_project)
         settings_c%logger  = c_funloc(mock_logger)
 
         ! convert to Fortran settings
@@ -612,29 +643,29 @@ contains
         if (.not. associated(settings%precond)) then
             test_assign_stability_f_c = .false.
             write (stderr, *) "test_assign_stability_f_c failed: Preconditioner "// &
-                "function not associated."
+                "function not associated with value."
         else
-            allocate(residual(n_param), precond_residual(n_param))
-            residual = 1.0_rp
-            call settings%precond(residual, 5.0_rp, precond_residual, error)
-            if (error /= 0) then
-                test_assign_stability_f_c = .false.
-                write (stderr, *) "test_assign_stability_f_c failed: "// &
-                    "Preconditioner function produced error."
-            end if
-            if (any(abs(precond_residual - 5.0_rp) > tol)) then
-                test_assign_stability_f_c = .false.
-                write (stderr, *) "test_assign_stability_f_c failed: Returned "// &
-                    "preconditioner output wrong."
-            end if
-            deallocate(residual, precond_residual)
+            test_assign_stability_f_c = test_assign_stability_f_c .and. &
+                test_precond_funptr(settings%precond, "assign_stability_f_c", &
+                                    " by preconditioner function")
+        end if
+
+        ! check projection function
+        if (.not. associated(settings%project)) then
+            test_assign_stability_f_c = .false.
+            write (stderr, *) "test_assign_stability_f_c failed: Projection "// &
+                "function not associated with value."
+        else
+            test_assign_stability_f_c = test_assign_stability_f_c .and. &
+            test_project_funptr(settings%project, "assign_stability_f_c", &
+                                " by projection function")
         end if
 
         ! check logging function
         if (.not. associated(settings%logger)) then
             test_assign_stability_f_c = .false.
             write (stderr, *) "test_assign_stability_f_c failed: Logging function "// &
-                "not associated."
+                "not associated with value."
         else
             test_logger = .true.
             call settings%logger("stability test")
@@ -688,6 +719,11 @@ contains
             write (stderr, *) "test_assign_solver_c_f failed: Preconditioner "// &
                 "function associated."
         end if
+        if (c_associated(settings_c%project)) then
+            test_assign_solver_c_f = .false.
+            write (stderr, *) "test_assign_solver_c_f failed: Projection function "// &
+                "associated."
+        end if
         if (c_associated(settings_c%conv_check)) then
             test_assign_solver_c_f = .false.
             write (stderr, *) "test_assign_solver_c_f failed: Convergence check "// &
@@ -740,6 +776,11 @@ contains
         if (c_associated(settings_c%precond)) then
             test_assign_stability_c_f = .false.
             write (stderr, *) "test_assign_stability_c_f failed: Preconditioner "// &
+                "function associated."
+        end if
+        if (c_associated(settings_c%project)) then
+            test_assign_stability_c_f = .false.
+            write (stderr, *) "test_assign_stability_c_f failed: Projection "// &
                 "function associated."
         end if
         if (c_associated(settings_c%logger)) then

--- a/tests/opentrustregion_mock.f90
+++ b/tests/opentrustregion_mock.f90
@@ -28,7 +28,8 @@ contains
         !
         use opentrustregion, only: solver_settings_type
         use test_reference, only: test_update_orbs_funptr, test_obj_func_funptr, &
-                                  test_precond_funptr, test_conv_check_funptr
+                                  test_precond_funptr, test_project_funptr, &
+                                  test_conv_check_funptr
 
         procedure(update_orbs_type), intent(in), pointer :: update_orbs_funptr
         procedure(obj_func_type), intent(in), pointer :: obj_func_funptr
@@ -70,6 +71,17 @@ contains
                                 " by given preconditioner subroutine")
         end if
 
+        ! check if optional projection subroutine is correctly passed
+        if (.not. associated(settings%project)) then
+            test_passed = .false.
+            write (stderr, *) "test_solver_c_wrapper failed: Passed projection "// &
+                "function not associated with value."
+        else
+            test_passed = test_passed .and. &
+            test_project_funptr(settings%project, "solver_c_wrapper", &
+                                " by given projection subroutine")
+        end if
+
         ! check if optional convergence check function is correctly passed
         if (.not. associated(settings%conv_check)) then
             test_passed = .false.
@@ -106,7 +118,8 @@ contains
         ! interface
         !
         use opentrustregion, only: stability_settings_type
-        use test_reference, only: test_hess_x_funptr, test_precond_funptr
+        use test_reference, only: test_hess_x_funptr, test_precond_funptr, &
+                                  test_project_funptr
 
         real(rp), intent(in) :: h_diag(:)
         procedure(hess_x_type), intent(in), pointer :: hess_x_funptr
@@ -144,6 +157,17 @@ contains
             test_passed = test_passed .and. &
             test_precond_funptr(settings%precond, "stability_check_c_wrapper", &
                                 " by given preconditioner subroutine")
+        end if
+
+        ! check if optional projection subroutine is correctly passed
+        if (.not. associated(settings%project)) then
+            test_passed = .false.
+            write (stderr, *) "test_stability_check_c_wrapper failed: Passed "// &
+                "projection function not associated with value."
+        else
+            test_passed = test_passed .and. &
+            test_project_funptr(settings%project, "stability_check_c_wrapper", &
+                                " by given projection subroutine")
         end if
 
         ! check if optional logging function is correctly passed

--- a/tests/test_reference.f90
+++ b/tests/test_reference.f90
@@ -499,6 +499,99 @@ contains
 
     end function test_precond_c_funptr
 
+    function test_project_funptr(project_funptr, test_name, message) result(test_passed)
+        !
+        ! this function tests a provided projection function pointer
+        !
+        use opentrustregion, only: project_type
+
+        procedure(project_type), intent(in), pointer :: project_funptr
+        character(*), intent(in) :: test_name, message
+        logical :: test_passed
+        
+        real(rp), allocatable :: vector(:)
+        integer(ip) :: error
+
+        ! assume tests pass
+        test_passed = .true.
+
+        ! allocate arrays
+        allocate(vector(n_param))
+
+        ! initialize vector
+        vector = 1.0_rp
+
+        ! call projection subroutine
+        call project_funptr(vector, error)
+
+        ! check for error
+        if (error /= 0) then
+            write (stderr, *) "test_"//test_name//" failed: Error produced"//message// &
+                "."
+            test_passed = .false.
+        end if
+
+        ! check projected vector
+        if (any(abs(vector - 2.0_rp) > tol)) then
+            write (stderr, *) "test_"//test_name//" failed: Projected vector "// &
+                "returned"//message//" wrong."
+            test_passed = .false.
+        end if
+
+        ! deallocate arrays
+        deallocate(vector)
+
+    end function test_project_funptr
+
+    function test_project_c_funptr(project_c_funptr, test_name, message) &
+        result(test_passed)
+        !
+        ! this function tests a provided projection C function pointer
+        !
+        use c_interface, only: project_c_type
+
+        type(c_funptr), intent(in) :: project_c_funptr
+        character(*), intent(in) :: test_name, message
+        logical :: test_passed
+
+        procedure(project_c_type), pointer :: project_funptr
+        real(c_rp), allocatable :: vector(:)
+        integer(c_ip) :: error
+
+        ! assume tests pass
+        test_passed = .true.
+
+        ! convert to Fortran function pointer
+        call c_f_procpointer(cptr=project_c_funptr, fptr=project_funptr)
+
+        ! allocate arrays
+        allocate(vector(n_param))
+
+        ! initialize vector
+        vector = 1.0_c_rp
+
+        ! call projection function
+        error = project_funptr(vector)
+
+        ! check for error
+        if (error /= 0) then
+            write (stderr, *) "test_"//test_name//" failed: Error produced"//message// &
+                "."
+            test_passed = .false.
+        end if
+
+        ! check projected vector
+        if (any(abs(vector - 2.0_c_rp) > tol_c)) then
+            write (stderr, *) "test_"//test_name//" failed: Projected vector "// &
+                "returned"//message//" wrong."
+            test_passed = .false.
+        end if
+
+        ! deallocate arrays
+        deallocate(vector)
+
+    end function test_project_c_funptr
+
     function test_conv_check_funptr(conv_check_funptr, test_name, message) &
         result(test_passed)
         !
@@ -597,6 +690,7 @@ contains
 
         ! unassociate function pointers
         lhs%precond => null()
+        lhs%project => null()
         lhs%conv_check => null()
         lhs%logger => null()
 
@@ -632,6 +726,7 @@ contains
 
         ! unassociate function pointers
         lhs%precond => null()
+        lhs%project => null()
         lhs%logger => null()
 
         ! set reference values


### PR DESCRIPTION
## Description
This PR introduces the ability to pass a custom `project` function to the optimization suite. This is primarily intended for optimization in non-redundant bases (e.g., AO basis), where vectors must be constrained to a specific subspace.

## Key Changes
* **Constraint Enforcement**: The `project` function is now invoked to ensure that both constructed trial vectors and preconditioned vectors remain within the defined optimization space.
* **Subroutine Requirements**: To maintain consistency, all other passed routines (`update_orbs`, `hess_x`, and `precond`) must remain **self-projecting**.
* **Enhanced Testing Infrastructure**: Updated the testsuite to allow for more precise comparison of printed log messages. This improvement was necessary to test the added features.