### PR TITLE
Reset solver iteration counters at entry to cover error paths

### DIFF
--- a/src/opentrustregion.f90
+++ b/src/opentrustregion.f90
@@ -215,6 +215,11 @@ contains
         ! initialize error flag
         error = 0
 
+        ! reset global counter variables so they do not accumulate across calls if a
+        ! previous call returned early on error or non-convergence
+        tot_orb_update = 0
+        tot_hess_x = 0
+
         ! initialize settings
         if (.not. settings%initialized) then
             call settings%init(error)
@@ -444,10 +449,6 @@ contains
         call settings%log(msg, verbosity_info)
         write (msg, '(A, I0)') "Total number of orbital updates: ", tot_orb_update
         call settings%log(msg, verbosity_info)
-
-        ! reset global counter variables
-        tot_orb_update = 0
-        tot_hess_x = 0
 
         ! flush output
         flush (stdout)


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                  
                                                                                                                                                                                              
  - `tot_orb_update` and `tot_hess_x` are module-level counters in `src/opentrustregion.f90:188`. The reset at `:448-450` only ran on the success path, so the non-convergence return at      
  `:436-437` and every error-return inside the macro loop left stale counts that bled into the next `solver` call's logged totals.                                                            
  - Moves the reset to the top of `solver`, alongside `error = 0`, so it covers every exit path. Removes the now-redundant reset on the success path.                                         
  - `stability_check` increments these counters but never reads or resets them — the counters belong to the `solver` lifetime, so leaving them untouched there is correct.                    
                                                                                                                                                                                              
  ## Test plan                                                                                                                                                                                
                                                                                                                                                                                              
  - [x] `cmake --build .` succeeds                                                                                                                                                            
  - [x] `python3 -m pyopentrustregion.testsuite` — all 53 tests pass                                                                                                                          
