### PR TITLE
Halve copy traffic in Davidson grow-helpers via move_alloc

### DIFF
--- a/src/opentrustregion.f90
+++ b/src/opentrustregion.f90
@@ -1004,24 +1004,22 @@ contains
         real(rp), allocatable, intent(inout) :: matrix(:, :)
         real(rp), intent(in) :: vector(:)
 
-        real(rp), allocatable :: temp(:, :)
+        real(rp), allocatable :: new_matrix(:, :)
+        integer(ip) :: nrows, ncols
 
-        ! copy data
-        temp = matrix
+        nrows = size(matrix, 1, kind=ip)
+        ncols = size(matrix, 2, kind=ip)
 
-        ! reallocate matrix
-        deallocate(matrix)
-        allocate(matrix(size(temp, 1) + 1, size(temp, 2) + 1))
-
-        ! copy data back
-        matrix(:size(temp, 1), :size(temp, 2)) = temp
+        ! allocate the larger matrix and copy existing contents only once
+        allocate(new_matrix(nrows + 1, ncols + 1))
+        new_matrix(:nrows, :ncols) = matrix
 
         ! add new row and column
-        matrix(:, size(temp, 2) + 1) = vector
-        matrix(size(temp, 1) + 1, :) = vector
+        new_matrix(:, ncols + 1) = vector
+        new_matrix(nrows + 1, :) = vector
 
-        ! deallocate temporary array
-        deallocate(temp)
+        ! transfer allocation back into matrix; old storage is freed by move_alloc
+        call move_alloc(new_matrix, matrix)
 
     end subroutine extend_symm_matrix
 
@@ -1032,23 +1030,21 @@ contains
         real(rp), allocatable, intent(inout) :: matrix(:, :)
         real(rp), intent(in) :: new_col(:)
 
-        real(rp), allocatable :: temp(:, :)
+        real(rp), allocatable :: new_matrix(:, :)
+        integer(ip) :: nrows, ncols
 
-        ! copy data
-        temp = matrix
+        nrows = size(matrix, 1, kind=ip)
+        ncols = size(matrix, 2, kind=ip)
 
-        ! reallocate matrix
-        deallocate(matrix)
-        allocate(matrix(size(temp, 1), size(temp, 2) + 1))
-
-        ! copy data back
-        matrix(:, :size(temp, 2)) = temp
+        ! allocate the wider matrix and copy existing contents only once
+        allocate(new_matrix(nrows, ncols + 1))
+        new_matrix(:, :ncols) = matrix
 
         ! add new column
-        matrix(:, size(temp, 2) + 1) = new_col
+        new_matrix(:, ncols + 1) = new_col
 
-        ! deallocate temporary array
-        deallocate(temp)
+        ! transfer allocation back into matrix; old storage is freed by move_alloc
+        call move_alloc(new_matrix, matrix)
 
     end subroutine add_column
 


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                  
                                                                                                                                                                                              
  - `extend_symm_matrix` and `add_column` in `src/opentrustregion.f90:1000-1053` are called once per Davidson micro iteration (`level_shifted_davidson` at `:610-619` and `:2083-2094`, plus  
  the `stability_check` path). Each call previously did: allocate `temp`, copy `matrix → temp`, deallocate `matrix`, allocate `matrix` at the new size, copy `temp → matrix`, deallocate      
  `temp` — two allocations and two full copies per growth.                                                                                                                                    
  - Restructure both helpers to allocate the new buffer once, copy the old contents once, and transfer ownership with `move_alloc`. Half the allocation traffic and half the copy traffic per 
  call, with `move_alloc` freeing the old buffer implicitly.                                                                                                                                  
  - This does not change the API or remove the underlying O(n_micro²) growth cost — eliminating the quadratic via amortized capacity doubling would require changing the helpers' contract    
  (every caller currently uses `size(matrix, 2)` to read the live extent). Leaving that as a follow-up.                                                                                       
                                                                                                                                                                                              
  ## Test plan                                                                                                                                                                                
                                                                                                                                                                                              
  - [x] `cmake --build .` succeeds with the existing test build                                                                                                                               
  - [x] `python3 -m pyopentrustregion.testsuite` — all 53 tests pass, including the Davidson and stability-check paths that exercise both helpers                                             
