### PR TITLE
Add OpenTrustRegion_HOST_PROVIDES_BLAS CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,9 +86,13 @@ if(INTEGER_SIZE)
 else()
     if(BLAS_LIBRARIES OR LAPACK_LIBRARIES)
         message(FATAL_ERROR
-            "You provided explicit BLAS or LAPACK libraries but did not specify INTEGER_SIZE. "
+            "Explicitly provided BLAS or LAPACK libraries require INTEGER_SIZE to be set. "
             "Please set INTEGER_SIZE to 4 (LP64) or 8 (ILP64) to ensure compatibility."
         )
+    elseif(${otr}_HOST_PROVIDES_BLAS)
+        message(FATAL_ERROR
+            "OpenTrustRegion_HOST_PROVIDES_BLAS requires INTEGER_SIZE to be set "
+            "Please set INTEGER_SIZE to 4 (LP64) or 8 (ILP64) to match the host's BLAS/LAPACK integer width.")
     else()
         # autodetect BLAS and LAPACK, try 32-bit first, then 64-bit
         set(BLA_SIZEOF_INTEGER 4 CACHE INTERNAL "BLAS/LAPACK integer size")
@@ -109,7 +113,7 @@ if(BLA_SIZEOF_INTEGER EQUAL 8)
     set(LIB_SUFFIX "64")
 
     # check whether 64-bit BLAS and LAPACK routines are called differently
-    if(NOT ${${otr}_HOST_PROVIDES_BLAS})
+    if(NOT ${otr}_HOST_PROVIDES_BLAS)
         set(CMAKE_REQUIRED_LIBRARIES ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
         check_fortran_function_exists("sgemm_64" BLAS_64)
         check_fortran_function_exists("sgesv_64" LAPACK_64)
@@ -172,7 +176,7 @@ set_source_files_properties(${OPENTRUSTREGION_SOURCES}
 )
 
 # link against BLAS and LAPACK (unless host provides these)
-if(NOT ${${otr}_HOST_PROVIDES_BLAS})
+if(NOT ${otr}_HOST_PROVIDES_BLAS)
     target_link_libraries(opentrustregion
                           PRIVATE ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES}
     )
@@ -186,7 +190,7 @@ target_include_directories(opentrustregion PUBLIC
 
 # option to build testsuite but skip when the host provides BLAS/LAPACK (tests require 
 # BLAS at build/link time)
-if (${otr}_BUILD_TESTING AND NOT ${${otr}_HOST_PROVIDES_BLAS})
+if (${otr}_BUILD_TESTING AND NOT ${otr}_HOST_PROVIDES_BLAS)
     # define test files
     set(OPENTRUSTREGION_TESTS
         tests/test_reference.f90

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,10 @@ option(${otr}_INSTALL_TESTING_LIBRARY "Install the compiled library used for tes
 message(STATUS "Showing option ${otr}_BUILD_TESTING: ${${otr}_BUILD_TESTING}")
 message(STATUS "Showing option ${otr}_INSTALL_TESTING_LIBRARY: ${${otr}_INSTALL_TESTING_LIBRARY}")
 
+# host program provides BLAS/LAPACK (skip find/link in this project)
+option(${otr}_HOST_PROVIDES_BLAS "Host program will provide BLAS/LAPACK; skip finding/linking them" OFF)
+message(STATUS "Showing option ${otr}_HOST_PROVIDES_BLAS: ${${otr}_HOST_PROVIDES_BLAS}")
+
 # default to static libraries
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 message(STATUS "Showing option BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
@@ -62,15 +66,22 @@ set(LAPACK_LIBRARIES "" CACHE STRING "User-specified LAPACK library path(s)")
 # check if integer size is provided
 if(INTEGER_SIZE)
     set(BLA_SIZEOF_INTEGER ${INTEGER_SIZE} CACHE INTERNAL "BLAS/LAPACK integer size")
-    if(BLAS_LIBRARIES)
-        message(STATUS "Using user-specified BLAS")
+    if(NOT ${otr}_HOST_PROVIDES_BLAS)
+        if(BLAS_LIBRARIES)
+            message(STATUS "Using user-specified BLAS")
+        else()
+            find_package(BLAS REQUIRED)
+        endif()
+        if(LAPACK_LIBRARIES)
+            message(STATUS "Using user-specified LAPACK")
+        else()
+            find_package(LAPACK REQUIRED)
+        endif()
     else()
-        find_package(BLAS REQUIRED)
-    endif()
-    if(LAPACK_LIBRARIES)
-        message(STATUS "Using user-specified LAPACK")
-    else()
-        find_package(LAPACK REQUIRED)
+        message(STATUS 
+            "Host will provide BLAS/LAPACK; skipping finding and linking these libraries "
+            "and building testsuite since tests require BLAS at build/link time"
+        )
     endif()
 else()
     if(BLAS_LIBRARIES OR LAPACK_LIBRARIES)
@@ -98,19 +109,24 @@ if(BLA_SIZEOF_INTEGER EQUAL 8)
     set(LIB_SUFFIX "64")
 
     # check whether 64-bit BLAS and LAPACK routines are called differently
-    set(CMAKE_REQUIRED_LIBRARIES ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
-    check_fortran_function_exists("sgemm_64" BLAS_64)
-    check_fortran_function_exists("sgesv_64" LAPACK_64)
-    if(BLAS_64)
-        add_compile_definitions("ddot=ddot_64")
-        add_compile_definitions("dnrm2=dnrm2_64")
-        add_compile_definitions("dgemv=dgemv_64")
-        add_compile_definitions("dgemm=dgemm_64")
-    endif()
-    if(LAPACK_64)
-        add_compile_definitions("dsyev=dsyev_64")
-        add_compile_definitions("dsysv=dsysv_64")
-        add_compile_definitions("zheev=zheev_64")
+    if(NOT ${${otr}_HOST_PROVIDES_BLAS})
+        set(CMAKE_REQUIRED_LIBRARIES ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+        check_fortran_function_exists("sgemm_64" BLAS_64)
+        check_fortran_function_exists("sgesv_64" LAPACK_64)
+        if(BLAS_64)
+            add_compile_definitions("ddot=ddot_64")
+            add_compile_definitions("dnrm2=dnrm2_64")
+            add_compile_definitions("dgemv=dgemv_64")
+            add_compile_definitions("dgemm=dgemm_64")
+        endif()
+        if(LAPACK_64)
+            add_compile_definitions("dsyev=dsyev_64")
+            add_compile_definitions("dsysv=dsysv_64")
+            add_compile_definitions("zheev=zheev_64")
+        endif()
+    else()
+        set(BLAS_64 FALSE)
+        set(LAPACK_64 FALSE)
     endif()
 else()
     set(LIB_SUFFIX "32")
@@ -155,10 +171,12 @@ set_source_files_properties(${OPENTRUSTREGION_SOURCES}
                             PROPERTIES Fortran_PREPROCESS ON
 )
 
-# link against BLAS and LAPACK
-target_link_libraries(opentrustregion
-                      PRIVATE ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES}
-)
+# link against BLAS and LAPACK (unless host provides these)
+if(NOT ${${otr}_HOST_PROVIDES_BLAS})
+    target_link_libraries(opentrustregion
+                          PRIVATE ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES}
+    )
+endif()
 
 # set include directories
 target_include_directories(opentrustregion PUBLIC
@@ -166,8 +184,9 @@ target_include_directories(opentrustregion PUBLIC
                            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-# option to build testsuite
-if (${otr}_BUILD_TESTING)
+# option to build testsuite but skip when the host provides BLAS/LAPACK (tests require 
+# BLAS at build/link time)
+if (${otr}_BUILD_TESTING AND NOT ${${otr}_HOST_PROVIDES_BLAS})
     # define test files
     set(OPENTRUSTREGION_TESTS
         tests/test_reference.f90

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,8 +91,9 @@ else()
         )
     elseif(${otr}_HOST_PROVIDES_BLAS)
         message(FATAL_ERROR
-            "OpenTrustRegion_HOST_PROVIDES_BLAS requires INTEGER_SIZE to be set "
-            "Please set INTEGER_SIZE to 4 (LP64) or 8 (ILP64) to match the host's BLAS/LAPACK integer width.")
+            "OpenTrustRegion_HOST_PROVIDES_BLAS requires INTEGER_SIZE to be set. "
+            "Please set INTEGER_SIZE to 4 (LP64) or 8 (ILP64) to match the host's BLAS/LAPACK integer width."
+        )
     else()
         # autodetect BLAS and LAPACK, try 32-bit first, then 64-bit
         set(BLA_SIZEOF_INTEGER 4 CACHE INTERNAL "BLAS/LAPACK integer size")

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The build process can be customized using the following CMake options:
 | **INTEGER_SIZE** | `STRING` | *(auto)* | Set the integer precision to `4` (32-bit) or `8` (64-bit). Required when providing custom BLAS/LAPACK libraries. Otherwise defaults to 32-bit integers and tries to locate compatible BLAS and LAPACK libraries. Falls back to 64-bit integers if 32-bit libraries cannot be found. The resulting library name reflects the chosen integer precision (`libopentrustregion_32.*` or `libopentrustregion_64.*`) |
 | **BLAS_LIBRARIES** | `PATH` | *(auto)* | Path(s) to BLAS libraries. If not provided, CMake attempts to locate a suitable BLAS automatically. |
 | **LAPACK_LIBRARIES** | `PATH` | *(auto)* | Path(s) to LAPACK libraries. If not provided, CMake attempts to locate a suitable LAPACK automatically. |
-| **OpenTrustRegion_HOST_PROVIDES_BLAS** | `BOOL` | `OFF` | Bypass internal BLAS/LAPACK detection assuming the calling program provides math libraries. |
+| **OpenTrustRegion_HOST_PROVIDES_BLAS** | `BOOL` | `OFF` | When enabled, OpenTrustRegion will not attempt to detect or link BLAS/LAPACK and the testsuite is automatically disabled. The calling program must provide BLAS/LAPACK routines that expose the unsuffixed symbol names (for example `ddot`, `dsyev`) with an integer width matching `INTEGER_SIZE`; otherwise linking will fail loudly. |
 
 ## Program Interfaces
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The build process can be customized using the following CMake options:
 | **INTEGER_SIZE** | `STRING` | *(auto)* | Set the integer precision to `4` (32-bit) or `8` (64-bit). Required when providing custom BLAS/LAPACK libraries. Otherwise defaults to 32-bit integers and tries to locate compatible BLAS and LAPACK libraries. Falls back to 64-bit integers if 32-bit libraries cannot be found. The resulting library name reflects the chosen integer precision (`libopentrustregion_32.*` or `libopentrustregion_64.*`) |
 | **BLAS_LIBRARIES** | `PATH` | *(auto)* | Path(s) to BLAS libraries. If not provided, CMake attempts to locate a suitable BLAS automatically. |
 | **LAPACK_LIBRARIES** | `PATH` | *(auto)* | Path(s) to LAPACK libraries. If not provided, CMake attempts to locate a suitable LAPACK automatically. |
+| **OpenTrustRegion_HOST_PROVIDES_BLAS** | `BOOL` | `OFF` | Bypass internal BLAS/LAPACK detection assuming the calling program provides math libraries. |
 
 ## Usage
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ for suffix in ["", "_32", "_64"]:
 else:
     libopentrustregion_file = None
 libtestsuite_file = f"libotrtestsuite.{ext}"
+libtestsuite_path = build_dir / libtestsuite_file
 
 
 class CMakeBuild(build_py):
@@ -58,8 +59,10 @@ class CMakeBuild(build_py):
                     libopentrustregion_path, target_dir / libopentrustregion_file
                 )
 
-            # always copy testsuite
-            shutil.copy(build_dir / libtestsuite_file, target_dir / libtestsuite_file)
+            # copy testsuite only if it exists (i.e., built and not skipped due to not 
+            # building tests or host-provided BLAS/LAPACK)
+            if libtestsuite_path.exists():
+                shutil.copy(libtestsuite_path, target_dir / libtestsuite_file)
 
         # run steps in parent class
         super().run()
@@ -68,7 +71,8 @@ class CMakeBuild(build_py):
 # update package_data dynamically
 package_data_files = ["test_data/*.bin"]
 if os.getenv("CONDA_BUILD", "0") != "1":
-    package_data_files.append(libtestsuite_file)
+    if libtestsuite_path.exists():
+        package_data_files.append(libtestsuite_file)
     if libopentrustregion_file is not None:
         package_data_files.append(libopentrustregion_file)
 


### PR DESCRIPTION
Introduces an option to completely bypass the internal BLAS/LAPACK requirement. This is useful when the host program provides its own BLAS/LAPACK engine, especially if symbol name mismatches occur (such as when the library defaults to a '_64' suffix that conflicts with the host). 

Enabling this option ensures that OpenTrustRegion seamlessly shares the exact same BLAS/LAPACK distribution that the calling program was linked with, preventing duplicate dependency compilation and linker collisions.