### PR TITLE
Fixed typing in python interface

### DIFF
--- a/pyopentrustregion/python_interface.py
+++ b/pyopentrustregion/python_interface.py
@@ -32,7 +32,7 @@ from ctypes import (
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Tuple, Callable, Optional, Any, Dict
+    from typing import Tuple, Callable, Optional, Any, Dict, Type, Union
 
 
 # load the opentrustregion library, fallback to testsuite in case opentrustregion was
@@ -51,49 +51,50 @@ lib_candidates = [
 if sys.platform != "win32":
     # libopentrustregion symbols not exported through libotrtestsuite on windows
     lib_candidates.append(f"libotrtestsuite.{ext}")
-lib = None
-
-# try to load from installed package (conda)
 conda_prefix = Path("/opt/anaconda1anaconda2anaconda3")
-for lib_name in lib_candidates:
-    conda_path_unix = conda_prefix / "lib" / lib_name
-    conda_path_wind = conda_prefix / "Library" / "bin" / lib_name
-    if conda_path_unix.exists():
-        lib = CDLL(str(conda_path_unix))
-    elif conda_path_wind.exists():
-        lib = CDLL(str(conda_path_wind))
 
-# fallback: try to load from installed package (site-packages)
-if lib is None:
+
+def _load_lib() -> CDLL:
+    # try to load from installed package (conda)
+    for lib_name in lib_candidates:
+        conda_path_unix = conda_prefix / "lib" / lib_name
+        conda_path_wind = conda_prefix / "Library" / "bin" / lib_name
+        if conda_path_unix.exists():
+            return CDLL(str(conda_path_unix))
+        elif conda_path_wind.exists():
+            return CDLL(str(conda_path_wind))
+
+    # fallback: try to load from installed package (site-packages)
     for lib_name in lib_candidates:
         lib_path = resources.files("pyopentrustregion") / lib_name
         if lib_path.is_file():
-            lib = CDLL(str(lib_path))
+            return CDLL(str(lib_path))
 
-# fallback: try to load from same directory (editable install)
-if lib is None:
+    # fallback: try to load from same directory (editable install)
     for lib_name in lib_candidates:
         local_path = os.path.join(os.path.dirname(__file__), lib_name)
         if os.path.exists(local_path):
-            lib = CDLL(local_path)
+            return CDLL(local_path)
 
-# fallback: try to load from ../build (development build)
-if lib is None:
+    # fallback: try to load from ../build (development build)
     for lib_name in lib_candidates:
         build_path = os.path.abspath(
             os.path.join(os.path.dirname(__file__), "../build", lib_name)
         )
         if os.path.exists(build_path):
-            lib = CDLL(build_path)
+            return CDLL(build_path)
 
-# if all failed
-if lib is None:
+    # if all failed
     raise FileNotFoundError(
         f"Cannot find either opentrustregion or testsuite library ({lib_candidates})"
     )
 
+
+lib = _load_lib()
+
 # determine integer size used in library
 ilp64 = c_bool.in_dll(lib, "ilp64")
+c_int: Type[Union[c_int32, c_int64]]
 if ilp64.value:
     c_int = c_int64
 else:


### PR DESCRIPTION
Summary:
- Wraps the library-loading fallback chain (conda → site-packages → editable install → ../build) into a `_load_lib()` function that returns on the first matching candidate, instead of a top-level `if`/`elif` chain assigning into a `lib = None` sentinel.
- Annotates `c_int `as `Type[Union[c_int32, c_int64]]` so its type is explicit rather than inferred from whichever branch happens to assign it.

Pure refactor, no behavior change.