### PR TITLE
Properly initialize optional callback functions to null

### DIFF
--- a/src/opentrustregion.f90
+++ b/src/opentrustregion.f90
@@ -133,9 +133,9 @@ module opentrustregion
         logical :: initialized = .false.
         real(rp) :: conv_tol
         integer(ip) :: n_random_trial_vectors, jacobi_davidson_start, seed, verbose
-        procedure(precond_type), pointer, nopass :: precond
-        procedure(project_type), pointer, nopass :: project
-        procedure(logger_type), pointer, nopass :: logger
+        procedure(precond_type), pointer, nopass :: precond => null()
+        procedure(project_type), pointer, nopass :: project => null()
+        procedure(logger_type), pointer, nopass :: logger => null()
     contains
         procedure :: log => print_message
         procedure(init_type), deferred :: init
@@ -155,7 +155,7 @@ module opentrustregion
         real(rp) :: start_trust_radius, global_red_factor, local_red_factor
         integer(ip) :: n_macro, n_micro
         character(kw_len) :: subsystem_solver
-        procedure(conv_check_type), pointer, nopass :: conv_check
+        procedure(conv_check_type), pointer, nopass :: conv_check => null()
     contains
         procedure :: init => init_solver_settings, print_results
     end type


### PR DESCRIPTION
Summary:
- `precond`, `project`, `logger`, and `conv_check `procedure-pointer components of `settings_type`/`solver_settings_type` had no default initializer, leaving their association status undefined for a variable declared without going through `init`.
- `init` copies from a parameter that does set them to `null()`, but the component declaration itself wasn't self-sufficient. Adds `=> null()` to each so the derived types have a well-defined default regardless of whether init has run yet.