### PR TITLE
Add specific error code for maximum iterations non-convergence in solver and stability_check

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,12 +359,21 @@ The library uses structured integer return codes to indicate whether a function 
 
 ### Error Codes (`EE`)
 
-The error field (`EE`) is currently always set to `01`. Future versions may define more specific codes for different failure modes.
+The error field (`EE`) is `01` for a general, unspecified error. Some origins define additional, more specific codes where the host program can plausibly react differently to them (e.g. by adjusting a setting and retrying):
+
+| Error Code | Meaning                                                                |
+|------------|------------------------------------------------------------------------|
+| `0101`     | General error in `solver` |
+| `0102`     | Orbital optimization did not converge within the maximum number of macro iterations (`n_macro`) |
+| `0201`     | General error in `stability_check` |
+| `0202`     | Stability check did not converge within the maximum number of iterations (`n_iter`) |
+
+Future versions may define more specific codes for other actionable failure modes.
 
 ### Example Error Codes
 
-| Error Code | Meaning                |
-|------------|------------------------|
-| `0101`     | Error in `solver`      |
-| `1201`     | Error in `update_orbs` |
+| Error Code | Meaning                   |
+|------------|---------------------------|
+| `0101`     | General error in `solver` |
+| `1201`     | Error in `update_orbs`    |
 

--- a/src/opentrustregion.f90
+++ b/src/opentrustregion.f90
@@ -481,6 +481,7 @@ contains
         real(rp), parameter :: stability_thresh = -1e-2_rp
         real(rp), external :: dnrm2, ddot
         external :: dgemm, dgemv
+        logical :: stability_converged
 
         ! initialize error flag
         error = 0
@@ -536,6 +537,9 @@ contains
         allocate(red_space_solution(n_trial), solution(n_param), h_solution(n_param), &
                  residual(n_param), basis_vec(n_param), h_basis_vec(n_param))
 
+        ! assume not converged
+        stability_converged = .false.
+
         ! loop over iterations
         do iter = 1, settings%n_iter
             ! solve reduced space problem
@@ -558,10 +562,16 @@ contains
             ! check convergence
             stability_rms = dnrm2(n_param, residual, 1_ip) / &
                 sqrt(real(n_param, kind=rp))
-            if (stability_rms < settings%conv_tol) exit
+            if (stability_rms < settings%conv_tol) then
+                stability_converged = .true.
+                exit
+            end if
 
             ! stop when reduced space grows larger than full space
-            if (n_trial >= n_param) exit
+            if (n_trial >= n_param) then
+                stability_converged = .true.
+                exit
+            end if
 
             if (settings%diag_solver == "davidson" .or. iter <= &
                 settings%jacobi_davidson_start) then
@@ -634,7 +644,7 @@ contains
         end do
 
         ! check if stability check has converged
-        if (stability_rms >= settings%conv_tol) then
+        if (.not. stability_converged) then
             call settings%log("Stability check has not converged in the given "// &
                               "number of iterations.", verbosity_error, .true.)
             error = error_stability_check_max_iter

--- a/src/opentrustregion.f90
+++ b/src/opentrustregion.f90
@@ -29,7 +29,11 @@ module opentrustregion
                            trust_radius_expand_factor = 1.2_rp
 
     ! define error codes
-    integer(ip), parameter :: error_solver = 100, error_stability_check = 200, &
+    integer(ip), parameter :: error_solver = 100, &
+                              error_solver_max_iter = error_solver + 2, &
+                              error_stability_check = 200, &
+                              error_stability_check_max_iter = error_stability_check + &
+                                                               2, &
                               error_obj_func = 1100, error_update_orbs = 1200, &
                               error_hess_x = 1300, error_precond = 1400, &
                               error_conv_check = 1500, error_project = 1600
@@ -438,7 +442,7 @@ contains
         if (.not. macro_converged) then
             call settings%log("Orbital optimization has not converged!", &
                               verbosity_error, .true.)
-            error = error_solver + 1
+            error = error_solver_max_iter
             return
         end if
 
@@ -627,9 +631,12 @@ contains
         end do
 
         ! check if stability check has converged
-        if (stability_rms >= settings%conv_tol) &
+        if (stability_rms >= settings%conv_tol) then
             call settings%log("Stability check has not converged in the given "// &
                               "number of iterations.", verbosity_error, .true.)
+            error = error_stability_check_max_iter
+            return
+        end if
 
         ! determine if saddle point
         stable = eigval > stability_thresh

--- a/tests/opentrustregion_unit_tests.f90
+++ b/tests/opentrustregion_unit_tests.f90
@@ -253,7 +253,8 @@ contains
         !
         use opentrustregion, only: update_orbs_type, obj_func_type, &
                                    solver_settings_type, solver, &
-                                   default_settings => default_solver_settings
+                                   default_settings => default_solver_settings, &
+                                   error_solver_max_iter
 
         real(rp), parameter :: var_thres = 1e-6_rp
         integer(ip) :: error
@@ -345,6 +346,21 @@ contains
             test_solver = .false.
         end if
 
+        ! force non-convergence by allowing only a single macro iteration from a
+        ! generic starting point and check that the specific maximum iteration error 
+        ! code is returned
+        curr_vars = [0.9_rp, 0.1_rp, 0.7_rp, 0.2_rp, 0.6_rp, 0.4_rp]
+        update_orbs_funptr => update_orbs
+        obj_func_funptr => obj_func
+        call settings%init(error)
+        settings%n_macro = 1
+        call solver(update_orbs_funptr, obj_func_funptr, n_param, error, settings)
+        if (error /= error_solver_max_iter) then
+            write (stderr, *) "test_solver failed: Did not return maximum "// &
+                "iteration error code when exceeding n_macro."
+            test_solver = .false.
+        end if
+
         ! deallocate space for the gradient
         deallocate(final_grad)
 
@@ -354,7 +370,8 @@ contains
         !
         ! this function tests the stability check subroutine
         !
-        use opentrustregion, only: hess_x_type, stability_settings_type, stability_check
+        use opentrustregion, only: hess_x_type, stability_settings_type, &
+                                   stability_check, error_stability_check_max_iter
 
         real(rp) :: vars(6), h_diag(6), direction(6)
         procedure(hess_x_type), pointer :: hess_x_funptr
@@ -419,6 +436,17 @@ contains
             > tol) then
             write (stderr, *) "test_stability_check failed: Stability check does "// &
                 "not return correct direction for saddle point."
+            test_stability_check = .false.
+        end if
+
+        ! force non-convergence by allowing only a single iteration and check that the 
+        ! specific maximum iteration error code is returned
+        call settings%init(error)
+        settings%n_iter = 1
+        call stability_check(h_diag, hess_x_funptr, stable, error, settings)
+        if (error /= error_stability_check_max_iter) then
+            write (stderr, *) "test_stability_check failed: Did not return maximum "// &
+                "iteration error code when exceeding n_iter."
             test_stability_check = .false.
         end if
 


### PR DESCRIPTION
Summary:

Partially addresses #48 (Point 3): the generic `EE = 01` error code conflated "ran out of macro iterations" with every other failure mode `solver `can hit, so Psi4 has no reliable way to implement its FAIL_ON_MAXITER keyword.
- this adds a distinct code only for the two failure modes that are actually actionable by the host program (a setting the caller can modify and retry), leaving everything else under the existing general code:
0102: `solver` did not converge within `n_macro` macro iterations
0202: `stability_check` did not converge within `n_iter` iterations
- includes regression tests for both new failure modes and README documentation.