### PR TITLE
Return solver/stability_check diagnostics through the settings object

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,18 +118,23 @@ settings%subsystem_solver = "tcg"
 
 ! run solver
 call solver(update_orbs_funptr, obj_func_funptr, n_param, error, settings)
+
+! read back output fields
+print *, "Number of orbital updates:", settings%n_update_orbs
 ```
 
 - Callback function pointers (`update_orbs_funptr`, `obj_func_funptr`) point to existing implementations elsewhere in the program.
 - `n_param` is also assumed to be defined elsewhere.
 - Solver settings are initialized using the `init()` method of the derived type, and default settings can be overridden (here, `conv_tol` and `n_macro`).
 - Finally, the `solver` is called with the initialized settings and callback functions.
+- After the call, output fields on `settings` (here, `n_update_orbs`) are populated and can be read like any other component.
 
 ---
 
 The following C snippet demonstrates the equivalent usage through the C interface:
 
 ```c
+#include <stdio.h>
 #include <string.h>
 #include "opentrustregion.h"
 
@@ -148,13 +153,17 @@ settings.n_macro = 100;
 strcpy(settings.subsystem_solver, "tcg");
 
 // run solver
-c_int error = solver(update_orbs_funptr, obj_func_funptr, n_param, settings);
+c_int error = solver(update_orbs_funptr, obj_func_funptr, n_param, &settings);
+
+// read back output fields
+printf("Number of orbital updates: %d\n", settings.n_update_orbs);
 ```
 
 - Callback function pointers (`update_orbs_funptr`, `obj_func_funptr`) point to existing implementations elsewhere in the program.
 - `n_param` is also assumed to be defined elsewhere.
 - Solver settings are initialized via a small helper function `solver_settings_init()`, which returns a struct with default values. Individual settings (here, `conv_tol` and `n_macro`) can then be overridden.
-- Finally, the `solver` is called with the initialized settings and callback functions and directly returns an error code in typical C fashion.
+- Finally, the `solver` is called with a pointer to the initialized settings and callback functions and directly returns an error code in typical C fashion.
+- After the call, output fields on `settings` (here, `n_update_orbs`) are populated and can be read like any other attribute.
 
 ---
 
@@ -173,12 +182,16 @@ settings.subsystem_solver = "tcg"
 
 # run solver
 solver(update_orbs, obj_func, n_param, settings)
+
+# read back output fields
+print(f"Number of orbital updates: {settings.n_update_orbs}")
 ```
 
 - Callback functions (`update_orbs`, `obj_func`) are defined elsewhere in the program.
 - `n_param` is also assumed to be defined elsewhere.
 - Solver settings are initialized via the `SolverSettings` class, which returns an object with default values; individual settings (here, `conv_tol`, and `n_macro`) can then be overridden.
 - Finally, the `solver` is called with the initialized settings and callback functions and errors can be caught in pythonic fashion in the form of a `RuntimeException`.
+- After the call, output fields on `settings` (here, `n_update_orbs`) are populated and can be read like any other attribute.
 
 ### Optional Settings
 The optimization process can be fine-tuned using the following settings:
@@ -203,6 +216,13 @@ The optimization process can be fine-tuned using the following settings:
 - **`verbose`** (integer): Controls the verbosity of output during optimization.
 - **`seed`** (integer): Seed value for generating random trial vectors.
 - **`logger`** (subroutine): Accepts a log message. Logging is otherwise routed to stdout.
+
+### Output
+After `solver` returns, the following fields on the settings object have been populated and can be read by the caller:
+
+- **`n_update_orbs`** (integer): Total number of orbital update calls (`update_orbs`) performed by this `solver` call.
+- **`n_hess_x`** (integer): Total number of Hessian linear transformations (`hess_x`) performed by this `solver` call.
+- **`max_precision_reached`** (boolean): `true` if the solver stopped because the objective function stopped changing, or the trust radius collapsed, at the limit of floating-point precision, rather than because the RMS gradient dropped below `conv_tol` or a custom `conv_check` reported convergence. `error` is still `0` and the returned point is still the best one found; this flag lets the host program decide whether to accept it as-is, warn, or retighten and retry with a different starting point or subsystem solver.
 
 ## Stability Check
 A separate `stability_check` subroutine is available to verify whether the current solution corresponds to a minimum. If not, it returns a boolean indicating instability and optionally, writes the eigenvector corresponding to the negative eigenvalue in-place to the provided memory.
@@ -244,6 +264,9 @@ settings%diag_solver = "jacobi-davidson"
 
 ! run stability check
 call stability_check(h_diag, hess_x_funptr, n_param, stable, error, settings, kappa=kappa)
+
+! read back output fields
+print *, "Number of Hessian linear transformations:", settings%n_hess_x
 ```
 
 - `hess_x_funptr` points to an existing Hessian-vector product implementation elsewhere in the program.
@@ -251,12 +274,14 @@ call stability_check(h_diag, hess_x_funptr, n_param, stable, error, settings, ka
 - Stability settings are initialized via the `init()` method of the derived type and can be overridden (here, `conv_tol` and `n_iter`).
 - The `stable` logical output receives the result of the stability check.
 - The descent direction `kappa` is optional and is only returned if provided.
+- After the call, output fields on `settings` (here, `n_hess_x`) are populated and can be read like any other component.
 
 ---
 
 The following C snippet demonstrates the equivalent usage through the C interface:
 
 ```c
+#include <stdio.h>
 #include <string.h>
 #include "opentrustregion.h"
 
@@ -279,7 +304,10 @@ double* h_diag;
 double* kappa;
 
 // run stability check
-c_int error = stability_check(h_diag, hess_x_funptr, n_param, &stable, settings, kappa);
+c_int error = stability_check(h_diag, hess_x_funptr, n_param, &stable, &settings, kappa);
+
+// read back output fields
+printf("Number of Hessian linear transformations: %d\n", settings.n_hess_x);
 ```
 
 - `hess_x_funptr` points to an existing Hessian-vector product implementation elsewhere in the program.
@@ -287,6 +315,7 @@ c_int error = stability_check(h_diag, hess_x_funptr, n_param, &stable, settings,
 - Stability settings are initialized via a small helper function `stability_settings_init()`, which returns a struct with default values; individual settings (here, `conv_tol` and `n_iter`) can then be overridden.
 - The `stable` output receives the result of the stability check which directly returns an error code in typical C fashion.
 - The descent direction `kappa` can be defined elsewhere if needed; otherwise, it can be set to `nullptr`.
+- After the call, output fields on `settings` (here, `n_hess_x`) are populated and can be read like any other component.
 
 ---
 
@@ -309,6 +338,9 @@ kappa = np.empty(n_param, dtype=np.float64)
 
 # run stability check
 stable = stability_check(h_diag, hess_x, n_param, settings, kappa=kappa)
+
+# read back output fields
+print(f"Number of Hessian linear transformations: {settings.n_hess_x}")
 ```
 
 - `hess_x` is an existing Hessian-vector product implementation elsewhere in the program.
@@ -316,6 +348,7 @@ stable = stability_check(h_diag, hess_x, n_param, settings, kappa=kappa)
 - Stability settings are initialized via the `StabilitySettings` class, which returns an object with default values; individual settings (here, `conv_tol`) can then be overridden.
 - The `stable` output receives the result of the stability check and errors can be caught in pythonic fashion in the form of a `RuntimeException`.
 - The descent direction `kappa` is optional and is only returned if provided.
+- After the call, output fields on `settings` (here, `n_hess_x`) are populated and can be read like any other attribute.
 
 ### Optional Settings
 The stability check can be fine-tuned using the following settings:
@@ -332,6 +365,11 @@ The stability check can be fine-tuned using the following settings:
 - **`verbose`** (integer): Controls the verbosity of output during the stability check.
 - **`seed`** (integer): Seed value for generating random trial vectors.
 - **`logger`** (function): Accepts a log message. Logging is otherwise routed to stdout.
+
+### Output
+After `stability_check` returns, the following field on the settings object has been populated and can be read by the caller:
+
+- **`n_hess_x`** (integer): Total number of Hessian linear transformations (`hess_x`) performed by this `stability_check` call.
 
 ## Error Code Structure
 

--- a/include/opentrustregion.h
+++ b/include/opentrustregion.h
@@ -84,6 +84,7 @@ typedef struct {
     c_bool stability;
     c_bool line_search;
     c_bool initialized;
+    c_bool max_precision_reached;
 
     c_real conv_tol;
     c_real start_trust_radius;
@@ -96,6 +97,8 @@ typedef struct {
     c_int jacobi_davidson_start;
     c_int seed;
     c_int verbose;
+    c_int n_update_orbs;
+    c_int n_hess_x;
 
     char subsystem_solver[OTR_KW_LEN + 1];
 } solver_settings_type;
@@ -118,6 +121,7 @@ typedef struct {
     c_int jacobi_davidson_start;
     c_int seed;
     c_int verbose;
+    c_int n_hess_x;
 
     char diag_solver[OTR_KW_LEN + 1];
 } stability_settings_type;
@@ -135,14 +139,14 @@ void init_stability_settings(stability_settings_type* settings);
  * @param update_orbs_ptr   Pointer to update_orbs callback
  * @param obj_func_ptr      Pointer to objective function callback
  * @param n_param           Number of parameters
- * @param settings          Struct of solver settings
+ * @param settings          Pointer to struct of solver settings
  * @return                  Integer error code from Fortran
  */
 c_int solver(
     update_orbs_fp update_orbs_ptr, 
     obj_func_fp obj_func_ptr, 
     c_int n_param, 
-    solver_settings_type settings
+    solver_settings_type* settings
 );
 
 /**
@@ -152,7 +156,7 @@ c_int solver(
  * @param hess_x_ptr        Pointer to Hessian–vector product callback
  * @param n_param           Number of parameters
  * @param stable            Pointer to bool that receives stability result
- * @param settings          Struct of stability solver settings
+ * @param settings          Pointer to struct of stability solver settings
  * @param kappa_ptr         Pointer to orbital rotation vector
  * @return                  Integer error code from Fortran
  */
@@ -161,7 +165,7 @@ c_int stability_check(
     hess_x_fp hess_x_ptr,
     c_int n_param,
     c_bool* stable,
-    stability_settings_type settings,
+    stability_settings_type* settings,
     const void* kappa_ptr
 );
 

--- a/pyopentrustregion/python_interface.py
+++ b/pyopentrustregion/python_interface.py
@@ -310,6 +310,7 @@ class SolverSettingsC(Structure):
         ("stability", c_bool),
         ("line_search", c_bool),
         ("initialized", c_bool),
+        ("max_precision_reached", c_bool),
         ("conv_tol", c_real),
         ("start_trust_radius", c_real),
         ("global_red_factor", c_real),
@@ -320,6 +321,8 @@ class SolverSettingsC(Structure):
         ("jacobi_davidson_start", c_int),
         ("seed", c_int),
         ("verbose", c_int),
+        ("n_update_orbs", c_int),
+        ("n_hess_x", c_int),
         ("subsystem_solver", c_char * (kw_len + 1)),
     ]
 
@@ -336,6 +339,7 @@ class StabilitySettingsC(Structure):
         ("jacobi_davidson_start", c_int),
         ("seed", c_int),
         ("verbose", c_int),
+        ("n_hess_x", c_int),
         ("diag_solver", c_char * (kw_len + 1)),
     ]
 
@@ -561,12 +565,12 @@ def solver(
         update_orbs_interface_type,
         obj_func_interface_type,
         c_int,
-        SolverSettingsC,
+        POINTER(SolverSettingsC),
     ]
 
     # call Fortran function
     error = lib.solver(
-        update_orbs_interface, obj_func_interface, n_param, settings.settings_c
+        update_orbs_interface, obj_func_interface, n_param, byref(settings.settings_c)
     )
 
     if error:
@@ -603,7 +607,7 @@ def stability_check(
         hess_x_interface_type,
         c_int,
         POINTER(c_bool),
-        StabilitySettingsC,
+        POINTER(StabilitySettingsC),
         c_void_p,
     ]
 
@@ -616,7 +620,7 @@ def stability_check(
         hess_x_interface,
         n_param,
         byref(stable),
-        settings.settings_c,
+        byref(settings.settings_c),
         kappa.ctypes.data_as(POINTER(c_real)) if kappa is not None else kappa,
     )
 

--- a/pyopentrustregion/testsuite.py
+++ b/pyopentrustregion/testsuite.py
@@ -721,6 +721,18 @@ class PySystemTests(unittest.TestCase):
         if not state["logger_called"]:
             print(" test_solver_py failed: Logger was not called.")
             test_passed = False
+        if settings.n_update_orbs <= 0:
+            print(
+                " test_solver_py failed: Orbital update transformation counters were "
+                "not populated."
+            )
+            test_passed = False
+        if settings.n_hess_x <= 0:
+            print(
+                " test_solver_py failed: Hessian linear transformation counters were "
+                "not populated."
+            )
+            test_passed = False
 
         # restart near the saddle - solver must still reach a known minimum
         state["curr"] = np.array([0.35, 0.59, 0.48, 0.40, 0.31, 0.32])
@@ -758,6 +770,12 @@ class PySystemTests(unittest.TestCase):
             print(
                 " test_stability_check_py failed: Stability incorrectly classifies "
                 "stability of minimum."
+            )
+            test_passed = False
+        if settings.n_hess_x <= 0:
+            print(
+                " test_stability_check_py failed: Hessian linear transformation "
+                "counter was not populated."
             )
             test_passed = False
 

--- a/src/c_interface.f90
+++ b/src/c_interface.f90
@@ -113,10 +113,10 @@ module c_interface
     ! derived type for solver settings
     type, bind(C) :: solver_settings_type_c
         type(c_funptr) :: precond, project, conv_check, logger
-        logical(c_bool) :: stability, line_search, initialized
+        logical(c_bool) :: stability, line_search, initialized, max_precision_reached
         real(c_rp) :: conv_tol, start_trust_radius, global_red_factor, local_red_factor
         integer(c_ip) :: n_random_trial_vectors, n_macro, n_micro, &
-                         jacobi_davidson_start, seed, verbose
+                         jacobi_davidson_start, seed, verbose, n_update_orbs, n_hess_x
         character(c_char) :: subsystem_solver(kw_len + 1)
     end type
 
@@ -125,7 +125,7 @@ module c_interface
         logical(c_bool) :: initialized
         real(c_rp) :: conv_tol
         integer(c_ip) :: n_random_trial_vectors, n_iter, jacobi_davidson_start, seed, &
-                         verbose
+                         verbose, n_hess_x
         character(c_char) :: diag_solver(kw_len + 1)
     end type
 
@@ -163,7 +163,7 @@ contains
 
         type(c_funptr), intent(in), value :: update_orbs_c_funptr, obj_func_c_funptr
         integer(c_ip), intent(in), value :: n_param_c
-        type(solver_settings_type_c), intent(in), value :: settings_c
+        type(solver_settings_type_c), intent(inout) :: settings_c
         integer(c_ip) :: error_c
 
         procedure(update_orbs_f_wrapper), pointer :: update_orbs
@@ -190,6 +190,12 @@ contains
         ! call solver
         call solver(update_orbs, obj_func, n_param, error, settings)
 
+        ! write output fields back into the C settings object directly
+        settings_c%max_precision_reached = logical(settings%max_precision_reached, &
+                                                   kind=c_bool)
+        settings_c%n_update_orbs = int(settings%n_update_orbs, kind=c_ip)
+        settings_c%n_hess_x = int(settings%n_hess_x, kind=c_ip)
+
         ! convert return arguments to C kind
         error_c = int(error, kind=c_ip)
 
@@ -207,7 +213,7 @@ contains
         integer(c_ip), intent(in), value :: n_param_c
         type(c_funptr), intent(in), value :: hess_x_c_funptr
         logical(c_bool), intent(out) :: stable_c
-        type(stability_settings_type_c), intent(in), value :: settings_c
+        type(stability_settings_type_c), intent(inout) :: settings_c
         type(c_ptr), intent(in), value :: kappa_c_ptr
         integer(c_ip) :: error_c
 
@@ -256,6 +262,9 @@ contains
             call stability_check(h_diag_ptr, hess_x, stable, error, settings)
         end if
         if (rp /= c_rp) deallocate(h_diag_ptr)
+
+        ! write output fields back into the C settings object directly
+        settings_c%n_hess_x = int(settings%n_hess_x, kind=c_ip)
 
         ! convert return arguments to C kind
         stable_c = logical(stable, kind=c_bool)
@@ -558,6 +567,7 @@ contains
             ! convert logicals
             settings%stability = logical(settings_c%stability)
             settings%line_search = logical(settings_c%line_search)
+            settings%max_precision_reached = logical(settings_c%max_precision_reached)
 
             ! convert reals
             settings%conv_tol = real(settings_c%conv_tol, kind=rp)
@@ -574,6 +584,8 @@ contains
                                                  kind=ip)
             settings%seed = int(settings_c%seed, kind=ip)
             settings%verbose = int(settings_c%verbose, kind=ip)
+            settings%n_update_orbs = int(settings_c%n_update_orbs, kind=ip)
+            settings%n_hess_x = int(settings_c%n_hess_x, kind=ip)
 
             ! convert characters
             settings%subsystem_solver = character_from_c(settings_c%subsystem_solver)
@@ -628,6 +640,7 @@ contains
                                                  kind=ip)
             settings%seed = int(settings_c%seed, kind=ip)
             settings%verbose = int(settings_c%verbose, kind=ip)
+            settings%n_hess_x = int(settings_c%n_hess_x, kind=ip)
 
             ! convert characters
             settings%diag_solver = character_from_c(settings_c%diag_solver)
@@ -657,6 +670,8 @@ contains
             ! convert logicals
             settings_c%stability = logical(settings%stability, kind=c_bool)
             settings_c%line_search = logical(settings%line_search, kind=c_bool)
+            settings_c%max_precision_reached = logical(settings%max_precision_reached, &
+                                                       kind=c_bool)
 
             ! convert reals
             settings_c%conv_tol = real(settings%conv_tol, kind=c_rp)
@@ -673,6 +688,8 @@ contains
                                                    kind=c_ip)
             settings_c%seed = int(settings%seed, kind=c_ip)
             settings_c%verbose = int(settings%verbose, kind=c_ip)
+            settings_c%n_update_orbs = int(settings%n_update_orbs, kind=c_ip)
+            settings_c%n_hess_x = int(settings%n_hess_x, kind=c_ip)
 
             ! convert characters
             settings_c%subsystem_solver = character_to_c(settings%subsystem_solver)
@@ -709,6 +726,7 @@ contains
                                                    kind=c_ip)
             settings_c%seed = int(settings%seed, kind=c_ip)
             settings_c%verbose = int(settings%verbose, kind=c_ip)
+            settings_c%n_hess_x = int(settings%n_hess_x, kind=c_ip)
 
             ! convert characters
             settings_c%diag_solver = character_to_c(settings%diag_solver)

--- a/src/opentrustregion.f90
+++ b/src/opentrustregion.f90
@@ -140,7 +140,8 @@ module opentrustregion
     type, abstract :: settings_type
         logical :: initialized = .false.
         real(rp) :: conv_tol
-        integer(ip) :: n_random_trial_vectors, jacobi_davidson_start, seed, verbose
+        integer(ip) :: n_random_trial_vectors, jacobi_davidson_start, seed, verbose, &
+                       n_hess_x = 0
         procedure(precond_type), pointer, nopass :: precond => null()
         procedure(project_type), pointer, nopass :: project => null()
         procedure(logger_type), pointer, nopass :: logger => null()
@@ -159,9 +160,9 @@ module opentrustregion
     end interface
 
     type, extends(settings_type) :: solver_settings_type
-        logical :: stability, line_search
+        logical :: stability, line_search, max_precision_reached = .false.
         real(rp) :: start_trust_radius, global_red_factor, local_red_factor
-        integer(ip) :: n_macro, n_micro
+        integer(ip) :: n_macro, n_micro, n_update_orbs = 0
         character(kw_len) :: subsystem_solver
         procedure(conv_check_type), pointer, nopass :: conv_check => null()
     contains
@@ -192,9 +193,6 @@ module opentrustregion
                                 jacobi_davidson_start = 50, seed = 42, verbose = 0, &
                                 diag_solver = "davidson")
 
-    ! define global variables
-    integer(ip) :: tot_orb_update = 0, tot_hess_x = 0
-
 contains
 
     subroutine solver(update_orbs, obj_func, n_param, error, settings)
@@ -223,10 +221,11 @@ contains
         ! initialize error flag
         error = 0
 
-        ! reset global counter variables so they do not accumulate across calls if a
-        ! previous call returned early on error or non-convergence
-        tot_orb_update = 0
-        tot_hess_x = 0
+        ! reset output fields so they do not accumulate across calls if a previous
+        ! call returned early on error or non-convergence
+        settings%max_precision_reached = .false.
+        settings%n_update_orbs = 0
+        settings%n_hess_x = 0
 
         ! initialize settings
         if (.not. settings%initialized) then
@@ -346,6 +345,10 @@ contains
                     call stability_check(h_diag, hess_x_funptr, stable, error, &
                                          stability_settings, kappa=kappa)
                     call add_error_origin(error, error_stability_check, settings)
+
+                    ! fold the internal stability check's Hessian linear
+                    ! transformations into the running total
+                    settings%n_hess_x = settings%n_hess_x + stability_settings%n_hess_x
                     if (error /= 0) return
                     if (.not. stable) then
                         ! logarithmic line search
@@ -386,10 +389,12 @@ contains
                         max_precision_reached = .false.
                         cycle
                     else
+                        settings%max_precision_reached = max_precision_reached
                         macro_converged = .true.
                         exit
                     end if
                 else
+                    settings%max_precision_reached = max_precision_reached
                     macro_converged = .true.
                     exit
                 end if
@@ -440,7 +445,7 @@ contains
         deallocate(kappa, grad, h_diag, solution, precond_kappa)
 
         ! increment total number of orbital updates
-        tot_orb_update = tot_orb_update + imacro
+        settings%n_update_orbs = settings%n_update_orbs + imacro
 
         ! stop if no convergence
         if (.not. macro_converged) then
@@ -453,9 +458,10 @@ contains
         ! finish logging
         call settings%log(repeat("-", 109), verbosity_info)
         write (msg, '(A, I0)') "Total number of Hessian linear transformations: ", &
-            tot_hess_x
+            settings%n_hess_x
         call settings%log(msg, verbosity_info)
-        write (msg, '(A, I0)') "Total number of orbital updates: ", tot_orb_update
+        write (msg, '(A, I0)') "Total number of orbital updates: ", &
+            settings%n_update_orbs
         call settings%log(msg, verbosity_info)
 
         ! flush output
@@ -492,6 +498,10 @@ contains
 
         ! initialize stable
         stable = .false.
+
+        ! reset output fields so they do not accumulate across calls if a previous
+        ! call returned early on error or non-convergence
+        settings%n_hess_x = 0
 
         ! initialize settings
         if (.not. settings%initialized) then
@@ -533,7 +543,7 @@ contains
         end do
 
         ! increment number of Hessian linear transformations
-        tot_hess_x = tot_hess_x + n_trial
+        settings%n_hess_x = settings%n_hess_x + n_trial
 
         ! construct augmented Hessian in reduced space
         allocate(red_space_hess(n_trial, n_trial))
@@ -605,7 +615,7 @@ contains
                 if (error /= 0) return
 
                 ! increment Hessian linear transformations
-                tot_hess_x = tot_hess_x + 1
+                settings%n_hess_x = settings%n_hess_x + 1
 
             else
                 ! solve Jacobi-Davidson correction equations
@@ -1650,7 +1660,7 @@ contains
         real(rp), intent(in) :: rhs(:), r_tol, solution(:), eigval
         procedure(hess_x_type), intent(in), pointer :: hess_x_funptr
         real(rp), intent(out) :: vec(:), hvec(:)
-        class(settings_type), intent(in) :: settings
+        class(settings_type), intent(inout) :: settings
         integer(ip), intent(out) :: error
         real(rp), intent(in), optional :: guess(:)
         integer(ip), intent(in), optional :: max_iter
@@ -1684,7 +1694,7 @@ contains
             call jacobi_davidson_correction(hess_x_funptr, vec, solution, eigval, &
                                             matvec, hvec, settings, error)
             if (error /= 0) return
-            tot_hess_x = tot_hess_x + 1
+            settings%n_hess_x = settings%n_hess_x + 1
         else
             vec = 0.0_rp
             hvec = 0.0_rp
@@ -1740,7 +1750,7 @@ contains
             call jacobi_davidson_correction(hess_x_funptr, v, solution, eigval, y, hv, &
                                             settings, error)
             if (error /= 0) return
-            tot_hess_x = tot_hess_x + 1
+            settings%n_hess_x = settings%n_hess_x + 1
 
             ! get new trial vector
             if (iteration >= 2) y = y - (beta / old_beta) * r1
@@ -2008,7 +2018,7 @@ contains
         integer(ip), intent(in) :: n_param
         procedure(obj_func_type), pointer, intent(in) :: obj_func
         procedure(hess_x_type), pointer, intent(in) :: hess_x_funptr
-        type(solver_settings_type), intent(in) :: settings
+        type(solver_settings_type), intent(inout) :: settings
         real(rp), intent(inout) :: trust_radius
         real(rp), intent(out) :: solution(:), mu
         integer(ip), intent(out) :: imicro, imicro_jacobi_davidson, error
@@ -2043,7 +2053,7 @@ contains
         n_trial = size(red_space_basis, 2)
 
         ! increment number of Hessian linear transformations
-        tot_hess_x = tot_hess_x + n_trial
+        settings%n_hess_x = settings%n_hess_x + n_trial
 
         ! calculate linear transformations of basis vectors
         allocate(h_basis(n_param, n_trial))
@@ -2186,7 +2196,7 @@ contains
                     if (error /= 0) return
 
                     ! increment Hessian linear transformations
-                    tot_hess_x = tot_hess_x + 1
+                    settings%n_hess_x = settings%n_hess_x + 1
 
                 else
                     ! solve Jacobi-Davidson correction equations
@@ -2278,7 +2288,7 @@ contains
         integer(ip), intent(in) :: n_param
         procedure(obj_func_type), pointer, intent(in) :: obj_func
         procedure(hess_x_type), pointer, intent(in) :: hess_x_funptr
-        type(solver_settings_type), intent(in) :: settings
+        type(solver_settings_type), intent(inout) :: settings
         real(rp), intent(inout) :: trust_radius
         real(rp), intent(out) :: solution(:)
         integer(ip), intent(out) :: imicro, error
@@ -2350,7 +2360,7 @@ contains
             if (error /= 0) return
 
             ! increment Hessian linear transformations
-            tot_hess_x = tot_hess_x + 1
+            settings%n_hess_x = settings%n_hess_x + 1
 
             ! calculate curvature
             curvature = ddot(n_param, direction, 1_ip, hess_direction, 1_ip)

--- a/tests/c_interface_mock.f90
+++ b/tests/c_interface_mock.f90
@@ -45,7 +45,7 @@ contains
 
         type(c_funptr), intent(in), value :: update_orbs_c_funptr, obj_func_c_funptr
         integer(c_ip), intent(in), value :: n_param_c
-        type(solver_settings_type_c), intent(in), value :: settings_c
+        type(solver_settings_type_c), intent(inout) :: settings_c
         integer(c_ip) :: error_c
 
         procedure(logger_c_type), pointer :: logger_funptr
@@ -116,7 +116,7 @@ contains
         type(c_funptr), intent(in), value :: hess_x_c_funptr
         integer(c_ip), intent(in), value :: n_param_c
         logical(c_bool), intent(out) :: stable_c
-        type(stability_settings_type_c), intent(in), value :: settings_c
+        type(stability_settings_type_c), intent(inout) :: settings_c
         type(c_ptr), intent(in), value :: kappa_c_ptr
         integer(c_ip) :: error_c
 

--- a/tests/c_system_tests.c
+++ b/tests/c_system_tests.c
@@ -280,6 +280,24 @@ bool test_solver_settings_init(void)
                 "NULL.\n");
         ok = false;
     }
+    if (s.max_precision_reached != defaults.max_precision_reached) {
+        fprintf(stderr,
+                "test_solver_settings_init failed: Maximum precision reached parameter "
+                "wrong.\n");
+        ok = false;
+    }
+    if (s.n_update_orbs != defaults.n_update_orbs) {
+        fprintf(stderr,
+                "test_solver_settings_init failed: Total number of orbital updates "
+                "parameter wrong.\n");
+        ok = false;
+    }
+    if (s.n_hess_x != defaults.n_hess_x) {
+        fprintf(stderr,
+                "test_solver_settings_init failed: Total number of Hessian linear "
+                "transformations parameter wrong.\n");
+        ok = false;
+    }
 
     return ok;
 }
@@ -346,6 +364,12 @@ bool test_stability_settings_init(void)
                 "NULL.\n");
         ok = false;
     }
+    if (s.n_hess_x != defaults.n_hess_x) {
+        fprintf(stderr,
+                "test_stability_settings_init failed: Total number of Hessian linear "
+                "transformations parameter wrong.\n");
+        ok = false;
+    }
 
     return ok;
 }
@@ -363,7 +387,7 @@ bool test_solver_c(void)
     // Start in the quadratic region near first minimum
     const c_real start_near_min1[N_PARAM] = {0.20, 0.15, 0.48, 0.28, 0.31, 0.66};
     memcpy(curr_vars, start_near_min1, sizeof(curr_vars));
-    c_int error = solver(update_orbs, obj_func, N_PARAM, settings);
+    c_int error = solver(update_orbs, obj_func, N_PARAM, &settings);
     if (error != 0) {
         fprintf(stderr, "test_solver_c failed: Produced error.\n"); ok = false;
     }
@@ -374,11 +398,17 @@ bool test_solver_c(void)
     if (!logger_called) {
         fprintf(stderr, "test_solver_c failed: Logger was not called.\n"); ok = false;
     }
+    if (settings.n_update_orbs <= 0 || settings.n_hess_x <= 0) {
+        fprintf(stderr,
+                "test_solver_c failed: Orbital update / Hessian linear "
+                "transformation counters were not populated.\n");
+        ok = false;
+    }
 
     // start near a saddle so the solver has to switch to a non-Newton step
     const c_real start_near_saddle[N_PARAM] = {0.35, 0.59, 0.48, 0.40, 0.31, 0.32};
     memcpy(curr_vars, start_near_saddle, sizeof(curr_vars));
-    error = solver(update_orbs, obj_func, N_PARAM, settings);
+    error = solver(update_orbs, obj_func, N_PARAM, &settings);
     if (error != 0) {
         fprintf(stderr,
                 "test_solver_c failed: Produced error when starting near saddle.\n");
@@ -410,7 +440,7 @@ bool test_stability_check_c(void)
     for (int i = 0; i < N_PARAM; i++) h_diag[i] = hess[i][i];
     c_real direction[N_PARAM] = {0};
     c_bool stable = false;
-    c_int error = stability_check(h_diag, hess_x_fun, N_PARAM, &stable, settings, 
+    c_int error = stability_check(h_diag, hess_x_fun, N_PARAM, &stable, &settings, 
                                   direction);
     if (error != 0) { 
         fprintf(stderr, "test_stability_check_c failed: Produced error.\n"); 
@@ -424,7 +454,13 @@ bool test_stability_check_c(void)
     }
     if (!logger_called) { 
         fprintf(stderr, "test_stability_check_c failed: Logger was not called.\n");
-        ok = false; 
+        ok = false;
+    }
+    if (settings.n_hess_x <= 0) {
+        fprintf(stderr,
+                "test_stability_check_c failed: Hessian linear transformation "
+                "counter was not populated.\n");
+        ok = false;
     }
 
     // at a saddle, expect unstable
@@ -433,7 +469,7 @@ bool test_stability_check_c(void)
     for (int i = 0; i < N_PARAM; i++) h_diag[i] = hess[i][i];
 
     stable = true;
-    error = stability_check(h_diag, hess_x_fun, N_PARAM, &stable, settings, direction);
+    error = stability_check(h_diag, hess_x_fun, N_PARAM, &stable, &settings, direction);
     if (error != 0) {
         fprintf(stderr, "test_stability_check_c failed: Produced error near saddle.\n");
         ok = false;
@@ -462,7 +498,7 @@ bool test_stability_check_c(void)
 
     // also exercise the no-direction path
     stable = true;
-    error = stability_check(h_diag, hess_x_fun, N_PARAM, &stable, settings, NULL);
+    error = stability_check(h_diag, hess_x_fun, N_PARAM, &stable, &settings, NULL);
     if (error != 0) {
         fprintf(stderr,
                 "test_stability_check_c failed: Produced error when not passing "

--- a/tests/opentrustregion_unit_tests.f90
+++ b/tests/opentrustregion_unit_tests.f90
@@ -360,6 +360,16 @@ contains
             write (stderr, *) "test_solver failed: Solver did not find correct minimum."
             test_solver = .false.
         end if
+        if (settings%n_update_orbs <= 0) then
+            write (stderr, *) "test_solver failed: Orbital update transformation "// &
+                "counters were not populated."
+            test_solver = .false.
+        end if
+        if (settings%n_hess_x <= 0) then
+            write (stderr, *) "test_solver failed: Hessian linear transformation "// &
+                "counters were not populated."
+            test_solver = .false.
+        end if
 
         ! start near saddle point
         curr_vars = [0.35_rp, 0.59_rp, 0.48_rp, 0.40_rp, 0.31_rp, 0.32_rp]
@@ -426,6 +436,29 @@ contains
             test_solver = .false.
         end if
 
+        ! force the maximum precision heuristic to trigger by requesting a convergence
+        ! tolerance that floating-point noise in the gradient can never satisfy
+        curr_vars = [0.20_rp, 0.15_rp, 0.48_rp, 0.28_rp, 0.31_rp, 0.66_rp]
+        update_orbs_funptr => update_orbs
+        obj_func_funptr => obj_func
+        call settings%init(error)
+        settings%conv_tol = 0.0_rp
+        settings%subsystem_solver = "tcg"
+
+        ! run solver, check that it still returns without error while flagging this in 
+        ! the settings object
+        call solver(update_orbs_funptr, obj_func_funptr, n_param, error, settings)
+        if (error /= 0) then
+            write (stderr, *) "test_solver failed: Produced error when forcing "// &
+                "maximum precision heuristic."
+            test_solver = .false.
+        end if
+        if (.not. settings%max_precision_reached) then
+            write (stderr, *) "test_solver failed: Did not flag that maximum "// &
+                "precision was reached when convergence tolerance could not be met."
+            test_solver = .false.
+        end if
+
         ! deallocate space for the gradient
         deallocate(final_grad)
 
@@ -472,6 +505,11 @@ contains
         if (all(abs(direction) > tol)) then
             write (stderr, *) "test_stability_check failed: Stability check does "// &
                 "not return zero vector for minimum"
+            test_stability_check = .false.
+        end if
+        if (settings%n_hess_x <= 0) then
+            write (stderr, *) "test_stability_check failed: Hessian linear "// &
+                "transformation counter was not populated."
             test_stability_check = .false.
         end if
 

--- a/tests/test_reference.f90
+++ b/tests/test_reference.f90
@@ -22,29 +22,32 @@ module test_reference
 
     ! derived types for solver settings
     type ref_settings_type
-        logical :: stability, line_search
+        logical :: stability, line_search, max_precision_reached
         real(rp) :: conv_tol, start_trust_radius, global_red_factor, local_red_factor
         integer(ip) :: n_random_trial_vectors, n_macro, n_micro, &
-                       jacobi_davidson_start, seed, verbose, n_iter
+                       jacobi_davidson_start, seed, verbose, n_update_orbs, n_hess_x, &
+                       n_iter
         character(kw_len, c_char) :: subsystem_solver, diag_solver
     end type
 
     type, bind(C) :: ref_settings_type_c
-        logical(c_bool) :: stability, line_search
+        logical(c_bool) :: stability, line_search, max_precision_reached
         real(c_rp) :: conv_tol, start_trust_radius, global_red_factor, local_red_factor
         integer(c_ip) :: n_random_trial_vectors, n_macro, n_micro, &
-                         jacobi_davidson_start, seed, verbose, n_iter
+                         jacobi_davidson_start, seed, verbose, n_update_orbs, &
+                         n_hess_x, n_iter
         character(c_char) :: subsystem_solver(kw_len + 1), diag_solver(kw_len + 1)
     end type
 
     ! general reference parameters
     type(ref_settings_type) :: ref_settings = &
         ref_settings_type(stability = .true., line_search = .true., &
-                          conv_tol = 1e-3_rp, start_trust_radius = 0.2_rp, &
-                          global_red_factor = 1e-2_rp, local_red_factor = 1e-3_rp, &
-                          n_random_trial_vectors = 5, n_macro = 300, n_micro = 200, &
-                          jacobi_davidson_start = 10, seed = 33, verbose = 3, &
-                          n_iter = 50, subsystem_solver = "tcg", &
+                          max_precision_reached = .true., conv_tol = 1e-3_rp, &
+                          start_trust_radius = 0.2_rp, global_red_factor = 1e-2_rp, &
+                          local_red_factor = 1e-3_rp, n_random_trial_vectors = 5, &
+                          n_macro = 300, n_micro = 200, jacobi_davidson_start = 10, &
+                          seed = 33, verbose = 3, n_iter = 50, n_update_orbs = 7, &
+                          n_hess_x = 11, subsystem_solver = "tcg", &
                           diag_solver = "jacobi-davidson")
 
     interface assignment(=)
@@ -723,6 +726,7 @@ contains
         ! set reference values
         lhs%stability = rhs%stability
         lhs%line_search = rhs%line_search
+        lhs%max_precision_reached = rhs%max_precision_reached
         lhs%conv_tol = rhs%conv_tol
         lhs%start_trust_radius = rhs%start_trust_radius
         lhs%global_red_factor = rhs%global_red_factor
@@ -733,6 +737,8 @@ contains
         lhs%jacobi_davidson_start = rhs%jacobi_davidson_start
         lhs%seed = rhs%seed
         lhs%verbose = rhs%verbose
+        lhs%n_update_orbs = rhs%n_update_orbs
+        lhs%n_hess_x = rhs%n_hess_x
         lhs%subsystem_solver = rhs%subsystem_solver
 
         ! set initialization logical
@@ -762,6 +768,7 @@ contains
         lhs%jacobi_davidson_start = rhs%jacobi_davidson_start
         lhs%seed = rhs%seed
         lhs%verbose = rhs%verbose
+        lhs%n_hess_x = rhs%n_hess_x
         lhs%diag_solver = rhs%diag_solver
 
         ! set initialization logical
@@ -817,6 +824,7 @@ contains
 
         lhs%stability = logical(rhs%stability, kind=c_bool)
         lhs%line_search = logical(rhs%line_search, kind=c_bool)
+        lhs%max_precision_reached = logical(rhs%max_precision_reached, kind=c_bool)
         lhs%conv_tol = real(rhs%conv_tol, kind=c_rp)
         lhs%start_trust_radius = real(rhs%start_trust_radius, kind=c_rp)
         lhs%global_red_factor = real(rhs%global_red_factor, kind=c_rp)
@@ -828,6 +836,8 @@ contains
         lhs%seed = int(rhs%seed, kind=c_ip)
         lhs%verbose = int(rhs%verbose, kind=c_ip)
         lhs%n_iter = int(rhs%n_iter, kind=c_ip)
+        lhs%n_update_orbs = int(rhs%n_update_orbs, kind=c_ip)
+        lhs%n_hess_x = int(rhs%n_hess_x, kind=c_ip)
         lhs%subsystem_solver = character_to_c(rhs%subsystem_solver)
         lhs%diag_solver = character_to_c(rhs%diag_solver)
 
@@ -845,6 +855,7 @@ contains
 
         equal_solver_to_ref = (lhs%stability .eqv. rhs%stability) .and. &
             (lhs%line_search .eqv. rhs%line_search) .and. &
+            (lhs%max_precision_reached .eqv. rhs%max_precision_reached) .and. &
             abs(lhs%conv_tol - rhs%conv_tol) <= tol .and. &
             abs(lhs%start_trust_radius - rhs%start_trust_radius) <= tol .and. &
             abs(lhs%global_red_factor - rhs%global_red_factor) <= tol .and. &
@@ -853,6 +864,8 @@ contains
             lhs%n_macro == rhs%n_macro .and. lhs%n_micro == rhs%n_micro .and. &
             lhs%jacobi_davidson_start == rhs%jacobi_davidson_start .and. &
             lhs%seed == rhs%seed .and. lhs%verbose == rhs%verbose .and. &
+            lhs%n_update_orbs == rhs%n_update_orbs .and. &
+            lhs%n_hess_x == rhs%n_hess_x .and. &
             lhs%subsystem_solver == rhs%subsystem_solver
 
     end function equal_solver_to_ref
@@ -886,7 +899,7 @@ contains
             lhs%n_iter == rhs%n_iter .and. &
             lhs%jacobi_davidson_start == rhs%jacobi_davidson_start .and. &
             lhs%seed == rhs%seed .and. lhs%verbose == rhs%verbose .and. &
-            lhs%diag_solver == rhs%diag_solver
+            lhs%n_hess_x == rhs%n_hess_x .and. lhs%diag_solver == rhs%diag_solver
 
     end function equal_stability_to_ref
 
@@ -980,6 +993,7 @@ contains
         equal_solver = (lhs%stability .eqv. rhs%stability) .and. &
             (lhs%line_search .eqv. rhs%line_search) .and. &
             (lhs%initialized .eqv. rhs%initialized) .and. &
+            (lhs%max_precision_reached .eqv. rhs%max_precision_reached) .and. &
             abs(lhs%conv_tol - rhs%conv_tol) <= tol .and. &
             abs(lhs%start_trust_radius - rhs%start_trust_radius) <= tol .and. &
             abs(lhs%global_red_factor - rhs%global_red_factor) <= tol .and. &
@@ -988,6 +1002,8 @@ contains
             lhs%n_macro == rhs%n_macro .and. lhs%n_micro == rhs%n_micro .and. &
             lhs%jacobi_davidson_start == rhs%jacobi_davidson_start .and. &
             lhs%seed == rhs%seed .and. lhs%verbose == rhs%verbose .and. &
+            lhs%n_update_orbs == rhs%n_update_orbs .and. &
+            lhs%n_hess_x == rhs%n_hess_x .and. &
             lhs%subsystem_solver == rhs%subsystem_solver
 
     end function equal_solver
@@ -1019,7 +1035,7 @@ contains
             lhs%n_iter == rhs%n_iter .and. &
             lhs%jacobi_davidson_start == rhs%jacobi_davidson_start .and. &
             lhs%seed == rhs%seed .and. lhs%verbose == rhs%verbose .and. &
-            lhs%diag_solver == rhs%diag_solver
+            lhs%n_hess_x == rhs%n_hess_x .and. lhs%diag_solver == rhs%diag_solver
 
     end function equal_stability
 


### PR DESCRIPTION
## 

**Status: WIP, targeting the next release. Breaks the C interface.**

Addresses #48 and generalizes the mechanism it needed. The solver can stop early when the objective function or trust radius hits the limit of double-precision floating-point resolution, rather than because `conv_tol`/ `conv_check` was actually satisfied. Previously indistinguishable from normal convergence, since `error` is `0` either way. Along the way, the existing `tot_orb_update`/`tot_hess_x` module-global counters were replaced with proper per-call output fields, since they were a natural fit for the same mechanism.

### What this adds
- `max_precision_reached` (boolean): set on `solver_settings_type` when the solver stopped via the floating-point-precision heuristic rather than genuine convergence. No error is raised for this since it's the best the solver can do.
- `n_update_orbs` / `n_hess_x` (integers): total orbital updates / Hessian linear transformations performed by the call. `n_hess_x` lives on the shared `settings_type` base since both `solver` and `stability_check` populate it; `n_update_orbs` is solver-only. These replace the old global counters.
- To support writing data back, `solver`'s and `stability_check`'s C prototypes now take `solver_settings_type*`/`stability_settings_type*` (previously by value).
- Fortran and Python callers are unaffected at the call-site level: settings were already `intent(inout)` in Fortran, and the Python `solver()`/`stability_check()` function signatures don't change.

### Breaking change
Any C code calling `solver(...)`/`stability_check(...)` directly needs to pass `&settings` instead of `settings` and recompile against the new header.