### PR TITLE
Fix Fortran coverage report inflating build/ noise and misfiring test exclude

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -253,7 +253,7 @@ jobs:
     - name: Build & Install OpenTrustRegion with Coverage Flags
       if: ${{ matrix.build-type == 'coverage' }}
       run: |
-        CMAKE_FLAGS="-DCMAKE_Fortran_FLAGS='--coverage -g'" pip install ${{github.workspace}}
+        CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_Fortran_FLAGS='--coverage -g'" pip install ${{github.workspace}}
 
     - name: Testing OpenTrustRegion with Coverage
       if: ${{ matrix.build-type == 'coverage' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -263,7 +263,7 @@ jobs:
       if: ${{ matrix.build-type == 'coverage' }}
       run: |
         coverage xml -o python_coverage.xml
-        gcovr -r . --exclude 'tests/*' --xml -o fortran_coverage.xml
+        gcovr -r . --exclude 'build/.*' --exclude 'tests/.*' --xml -o fortran_coverage.xml
 
     - name: Upload to Codecov
       if: ${{ matrix.build-type == 'coverage' }}

--- a/src/opentrustregion.f90
+++ b/src/opentrustregion.f90
@@ -1452,9 +1452,14 @@ contains
             norm = dnrm2(n_param, vector, 1_ip)
             if (norm < numerical_zero) then
                 error = error_gram_schmidt_lin_dep
-                if (.not. present(silent_on_error) .or. .not. silent_on_error) &
+                if (present(silent_on_error)) then
+                    if (.not. silent_on_error) &
+                        call settings%log(gram_schmidt_lin_dep_error_msg, &
+                                          verbosity_error, .true.)
+                else
                     call settings%log(gram_schmidt_lin_dep_error_msg, verbosity_error, &
                                       .true.)
+                end if
                 return
             end if
             vector = vector / norm


### PR DESCRIPTION
Excludes CMake's own compiler-detection probe from the line count, corrects a tests/ exclude pattern that was matching substrings instead of the directory, and builds the coverage job in Debug mode so -O2 doesn't collapse and hide real coverable lines.