### PR TITLE
Allow the solver's internal stability check to be configured via nested stability_settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ The optimization process can be fine-tuned using the following settings:
 - **`verbose`** (integer): Controls the verbosity of output during optimization.
 - **`seed`** (integer): Seed value for generating random trial vectors.
 - **`logger`** (subroutine): Accepts a log message. Logging is otherwise routed to stdout.
+- **`stability_settings`** (stability_settings_type): Settings object controlling the internal stability check that is automatically performed upon convergence when `stability` is `True` or when starting at a stationary point (see the Stability Check section below). If `stability_settings%precond`, `stability_settings%project`, or `stability_settings%logger` are left unset, they default to the corresponding `precond`, `project`, and `logger` supplied to `solver`. `stability_settings%verbose` is raised to at least the solver's own `verbose` level.
 
 ## Stability Check
 A separate `stability_check` subroutine is available to verify whether the current solution corresponds to a minimum. If not, it returns a boolean indicating instability and optionally, writes the eigenvector corresponding to the negative eigenvalue in-place to the provided memory.

--- a/include/opentrustregion.h
+++ b/include/opentrustregion.h
@@ -74,6 +74,28 @@ typedef logger_fn* logger_fp;
  * Structs corresponding to Fortran settings
  * ------------------------------------------------------------------ */
 
+// Struct corresponding to Fortran type(stability_settings_type_c)
+typedef struct {
+    precond_fp precond;
+    project_fp project;
+    logger_fp logger;
+
+    c_bool initialized;
+
+    c_real conv_tol;
+
+    c_int n_random_trial_vectors;
+    c_int n_iter;
+    c_int jacobi_davidson_start;
+    c_int seed;
+    c_int verbose;
+
+    char diag_solver[OTR_KW_LEN + 1];
+} stability_settings_type;
+
+// Fortran-callable init subroutine for stability check settings
+void init_stability_settings(stability_settings_type* settings);
+
 // Struct corresponding to Fortran type(solver_settings_type_c)
 typedef struct {
     precond_fp precond;
@@ -98,32 +120,12 @@ typedef struct {
     c_int verbose;
 
     char subsystem_solver[OTR_KW_LEN + 1];
+
+    stability_settings_type stability_settings;
 } solver_settings_type;
 
 // Fortran-callable init subroutine for solver settings
 void init_solver_settings(solver_settings_type* settings);
-
-// Struct corresponding to Fortran type(stability_settings_type_c)
-typedef struct {
-    precond_fp precond;
-    project_fp project;
-    logger_fp logger;
-
-    c_bool initialized;
-
-    c_real conv_tol;
-
-    c_int n_random_trial_vectors;
-    c_int n_iter;
-    c_int jacobi_davidson_start;
-    c_int seed;
-    c_int verbose;
-
-    char diag_solver[OTR_KW_LEN + 1];
-} stability_settings_type;
-
-// Fortran-callable init subroutine for stability check settings
-void init_stability_settings(stability_settings_type* settings);
 
 /* ------------------------------------------------------------------
  * Fortran wrappers

--- a/pyopentrustregion/python_interface.py
+++ b/pyopentrustregion/python_interface.py
@@ -301,6 +301,22 @@ class LoggerInterface:
 
 
 # define classes corresponding to C structs for settings
+class StabilitySettingsC(Structure):
+    _fields_ = [
+        ("precond", c_void_p),
+        ("project", c_void_p),
+        ("logger", c_void_p),
+        ("initialized", c_bool),
+        ("conv_tol", c_real),
+        ("n_random_trial_vectors", c_int),
+        ("n_iter", c_int),
+        ("jacobi_davidson_start", c_int),
+        ("seed", c_int),
+        ("verbose", c_int),
+        ("diag_solver", c_char * (kw_len + 1)),
+    ]
+
+
 class SolverSettingsC(Structure):
     _fields_ = [
         ("precond", c_void_p),
@@ -321,22 +337,7 @@ class SolverSettingsC(Structure):
         ("seed", c_int),
         ("verbose", c_int),
         ("subsystem_solver", c_char * (kw_len + 1)),
-    ]
-
-
-class StabilitySettingsC(Structure):
-    _fields_ = [
-        ("precond", c_void_p),
-        ("project", c_void_p),
-        ("logger", c_void_p),
-        ("initialized", c_bool),
-        ("conv_tol", c_real),
-        ("n_random_trial_vectors", c_int),
-        ("n_iter", c_int),
-        ("jacobi_davidson_start", c_int),
-        ("seed", c_int),
-        ("verbose", c_int),
-        ("diag_solver", c_char * (kw_len + 1)),
+        ("stability_settings", StabilitySettingsC),
     ]
 
 
@@ -346,7 +347,7 @@ class Settings:
     c_struct: type[Structure]
     init_c_struct: Any
 
-    def __init__(self):
+    def __init__(self, settings_c: Optional[Structure] = None):
         """
         this function initializes the settings class
         """
@@ -354,9 +355,13 @@ class Settings:
         self.init_c_struct.argtypes = [POINTER(self.c_struct)]
         self.init_c_struct.restype = None
 
-        # call C-side initialization to populate defaults
-        self.settings_c = self.c_struct()
-        self.init_c_struct(byref(self.settings_c))
+        # call C-side initialization to populate defaults, use passed settings if
+        # provided
+        if settings_c is None:
+            self.settings_c = self.c_struct()
+            self.init_c_struct(byref(self.settings_c))
+        else:
+            self.settings_c = settings_c
 
         # initializes all optional function pointers to None
         for field_info in self.settings_c._fields_:
@@ -399,6 +404,16 @@ class SolverSettings(Settings):
     conv_check_interface: Any
     logger_interface: Any
 
+    def __init__(self):
+        super().__init__()
+        self._stability_settings = StabilitySettings(
+            settings_c=self.settings_c.stability_settings
+        )
+
+    @property
+    def stability_settings(self) -> "StabilitySettings":
+        return self._stability_settings
+
     def set_optional_callbacks(self, n_param: int, exception: Dict[str, Exception]):
         """
         this function sets the interfaces for the optional callback functions
@@ -429,6 +444,7 @@ class SolverSettings(Settings):
         self.set_optional_callback(
             "logger", self.logger, LoggerInterface, logger_interface_type
         )
+        self.stability_settings.set_optional_callbacks(n_param, exception)
 
 
 class StabilitySettings(Settings):
@@ -476,8 +492,11 @@ def auto_bind_fields(cls: type[Settings]):
     for field_info in cls.c_struct._fields_:
         field_name, field_type = field_info[:2]
 
-        # skip if function pointer, these will be initialized separately
-        if field_type is c_void_p:
+        # skip if function pointer (these will be initialized separately) or nested
+        # structures
+        if field_type is c_void_p or (
+            isinstance(field_type, type) and issubclass(field_type, Structure)
+        ):
             continue
 
         # character arrays need to be handled separately

--- a/pyopentrustregion/testsuite.py
+++ b/pyopentrustregion/testsuite.py
@@ -332,9 +332,24 @@ class PyInterfaceTests(unittest.TestCase):
         settings.logger = mock_logger
         for field_info in settings.c_struct._fields_:
             field_name, field_type = field_info[:2]
-            if field_type == c_void_p or field_name == "initialized":
+            if (
+                field_type == c_void_p
+                or field_name == "initialized"
+                or (isinstance(field_type, type) and issubclass(field_type, Structure))
+            ):
                 continue
             setattr(settings, field_name, getattr(self, field_name + "_ref"))
+
+        # set reference values for nested stability check settings
+        for field_info in settings.stability_settings.c_struct._fields_:
+            field_name, field_type = field_info[:2]
+            if field_type == c_void_p or field_name == "initialized":
+                continue
+            setattr(
+                settings.stability_settings,
+                field_name,
+                getattr(self, field_name + "_ref"),
+            )
 
         # initialize logging boolean
         test_logger = False
@@ -465,6 +480,8 @@ class PyInterfaceTests(unittest.TestCase):
                         "initialized correctly."
                     )
                     test_passed = False
+            elif isinstance(field_type, type) and issubclass(field_type, Structure):
+                continue
             else:
                 ref_value = getattr(self, field_name + "_ref")
                 if field_type == c_real:
@@ -476,6 +493,43 @@ class PyInterfaceTests(unittest.TestCase):
                     print(
                         f" test_solver_settings failed: Field {field_name} not "
                         "initialized correctly."
+                    )
+                    test_passed = False
+
+        # check nested stability check settings
+        stability_settings = settings.stability_settings
+        for field_info in stability_settings.c_struct._fields_:
+            field_name, field_type = field_info[:2]
+            if field_type == c_void_p:
+                if (
+                    getattr(stability_settings, field_name) is not None
+                    or getattr(stability_settings.settings_c, field_name) is not None
+                ):
+                    print(
+                        " test_solver_settings failed: Optional function pointer "
+                        f"{field_name} not initialized correctly for nested "
+                        "stability settings."
+                    )
+                    test_passed = False
+            elif field_name == "initialized":
+                if not getattr(stability_settings, field_name):
+                    print(
+                        " test_solver_settings failed: Field initialized not "
+                        "initialized correctly for nested stability settings."
+                    )
+                    test_passed = False
+            else:
+                ref_value = getattr(self, field_name + "_ref")
+                if field_type == c_real:
+                    match = np.isclose(
+                        getattr(stability_settings, field_name), ref_value
+                    )
+                else:
+                    match = getattr(stability_settings, field_name) == ref_value
+                if not match:
+                    print(
+                        f" test_solver_settings failed: Field {field_name} not "
+                        "initialized correctly for nested stability settings."
                     )
                     test_passed = False
 

--- a/src/c_interface.f90
+++ b/src/c_interface.f90
@@ -110,6 +110,16 @@ module c_interface
         end subroutine logger_c_type
     end interface
 
+    ! derived type for stability check settings
+    type, bind(C) :: stability_settings_type_c
+        type(c_funptr) :: precond, project, logger
+        logical(c_bool) :: initialized
+        real(c_rp) :: conv_tol
+        integer(c_ip) :: n_random_trial_vectors, n_iter, jacobi_davidson_start, seed, &
+                         verbose
+        character(c_char) :: diag_solver(kw_len + 1)
+    end type
+
     ! derived type for solver settings
     type, bind(C) :: solver_settings_type_c
         type(c_funptr) :: precond, project, conv_check, logger
@@ -118,15 +128,7 @@ module c_interface
         integer(c_ip) :: n_random_trial_vectors, n_macro, n_micro, &
                          jacobi_davidson_start, seed, verbose
         character(c_char) :: subsystem_solver(kw_len + 1)
-    end type
-
-    type, bind(C) :: stability_settings_type_c
-        type(c_funptr) :: precond, project, logger
-        logical(c_bool) :: initialized
-        real(c_rp) :: conv_tol
-        integer(c_ip) :: n_random_trial_vectors, n_iter, jacobi_davidson_start, seed, &
-                         verbose
-        character(c_char) :: diag_solver(kw_len + 1)
+        type(stability_settings_type_c) :: stability_settings
     end type
 
     procedure(standard_solver), pointer :: solver => standard_solver
@@ -578,6 +580,9 @@ contains
             ! convert characters
             settings%subsystem_solver = character_from_c(settings_c%subsystem_solver)
 
+            ! convert objects
+            settings%stability_settings = settings_c%stability_settings
+
             ! set settings to initialized
             settings%initialized = .true.
         end if
@@ -676,6 +681,9 @@ contains
 
             ! convert characters
             settings_c%subsystem_solver = character_to_c(settings%subsystem_solver)
+
+            ! convert objects
+            settings_c%stability_settings = settings%stability_settings
 
             ! set settings to initialized
             settings_c%initialized = .true._c_bool

--- a/src/opentrustregion.f90
+++ b/src/opentrustregion.f90
@@ -346,6 +346,8 @@ contains
                         settings%stability_settings%project => settings%project
                     if (.not. associated(settings%stability_settings%logger)) &
                         settings%stability_settings%logger => settings%logger
+                    settings%stability_settings%verbose = &
+                        max(settings%stability_settings%verbose, settings%verbose)
                     call stability_check(h_diag, hess_x_funptr, stable, error, &
                                          settings%stability_settings, kappa=kappa)
                     call add_error_origin(error, error_stability_check, settings)

--- a/src/opentrustregion.f90
+++ b/src/opentrustregion.f90
@@ -158,16 +158,6 @@ module opentrustregion
         end subroutine init_type
     end interface
 
-    type, extends(settings_type) :: solver_settings_type
-        logical :: stability, line_search
-        real(rp) :: start_trust_radius, global_red_factor, local_red_factor
-        integer(ip) :: n_macro, n_micro
-        character(kw_len) :: subsystem_solver
-        procedure(conv_check_type), pointer, nopass :: conv_check => null()
-    contains
-        procedure :: init => init_solver_settings, print_results
-    end type
-
     type, extends(settings_type) :: stability_settings_type
         integer(ip) :: n_iter
         character(kw_len) :: diag_solver
@@ -175,7 +165,24 @@ module opentrustregion
         procedure :: init => init_stability_settings
     end type
 
+    type, extends(settings_type) :: solver_settings_type
+        logical :: stability, line_search
+        real(rp) :: start_trust_radius, global_red_factor, local_red_factor
+        integer(ip) :: n_macro, n_micro
+        character(kw_len) :: subsystem_solver
+        type(stability_settings_type) :: stability_settings
+        procedure(conv_check_type), pointer, nopass :: conv_check => null()
+    contains
+        procedure :: init => init_solver_settings, print_results
+    end type
+
     ! default settings
+    type(stability_settings_type), parameter :: default_stability_settings = &
+        stability_settings_type(precond = null(), project = null(), logger = null(), &
+                                initialized = .true., conv_tol = 1e-8_rp, &
+                                n_random_trial_vectors = 20, n_iter = 100, &
+                                jacobi_davidson_start = 50, seed = 42, verbose = 0, &
+                                diag_solver = "davidson")
     type(solver_settings_type), parameter :: default_solver_settings = &
         solver_settings_type(precond = null(), project = null(), conv_check = null(), &
                              logger = null(), stability = .false., &
@@ -184,13 +191,8 @@ module opentrustregion
                              global_red_factor = 1e-3_rp, local_red_factor = 1e-4_rp, &
                              n_random_trial_vectors = 1, n_macro = 150, n_micro = 50, &
                              jacobi_davidson_start = 30, seed = 42, verbose = 0, &
-                             subsystem_solver = "davidson")
-    type(stability_settings_type), parameter :: default_stability_settings = &
-        stability_settings_type(precond = null(), project = null(), logger = null(), &
-                                initialized = .true., conv_tol = 1e-8_rp, &
-                                n_random_trial_vectors = 20, n_iter = 100, &
-                                jacobi_davidson_start = 50, seed = 42, verbose = 0, &
-                                diag_solver = "davidson")
+                             subsystem_solver = "davidson", &
+                             stability_settings = default_stability_settings)
 
     ! define global variables
     integer(ip) :: tot_orb_update = 0, tot_hess_x = 0
@@ -207,7 +209,6 @@ contains
         integer(ip), intent(out) :: error
         type(solver_settings_type), intent(inout) :: settings
 
-        type(stability_settings_type) :: stability_settings
         real(rp) :: trust_radius, func, grad_norm, grad_rms, mu, new_func, n_kappa, &
                     kappa_norm
         real(rp), allocatable :: kappa(:), grad(:), h_diag(:), solution(:), &
@@ -337,14 +338,16 @@ contains
                 conv_check_passed) then
                 ! always perform stability check if starting at stationary point
                 if (settings%stability .or. imacro == 1) then
-                    call stability_settings%init(error)
-                    call add_error_origin(error, error_solver, settings)
-                    if (error /= 0) return
-                    stability_settings%precond => settings%precond
-                    stability_settings%verbose = settings%verbose
-                    stability_settings%logger => settings%logger
+                    ! inherit preconditioning, projection and logging functions from
+                    ! solver if not provided for stability check
+                    if (.not. associated(settings%stability_settings%precond)) &
+                        settings%stability_settings%precond => settings%precond
+                    if (.not. associated(settings%stability_settings%project)) &
+                        settings%stability_settings%project => settings%project
+                    if (.not. associated(settings%stability_settings%logger)) &
+                        settings%stability_settings%logger => settings%logger
                     call stability_check(h_diag, hess_x_funptr, stable, error, &
-                                         stability_settings, kappa=kappa)
+                                         settings%stability_settings, kappa=kappa)
                     call add_error_origin(error, error_stability_check, settings)
                     if (error /= 0) return
                     if (.not. stable) then

--- a/tests/c_system_tests.c
+++ b/tests/c_system_tests.c
@@ -281,6 +281,64 @@ bool test_solver_settings_init(void)
         ok = false;
     }
 
+    // compare nested stability check values
+    stability_settings_type stability_defaults = defaults.stability_settings;
+    stability_settings_type ss = s.stability_settings;
+    if (!ss.initialized) {
+        fprintf(stderr,
+                "test_solver_settings_init failed: Nested stability settings not "
+                "initialized.\n");
+        ok = false;
+    }
+    if (fabs(ss.conv_tol - stability_defaults.conv_tol) > 1e-20) {
+        fprintf(stderr,
+                "test_solver_settings_init failed: Nested stability convergence "
+                "tolerance parameter wrong.\n");
+        ok = false;
+    }
+    if (ss.n_random_trial_vectors != stability_defaults.n_random_trial_vectors) {
+        fprintf(stderr,
+                "test_solver_settings_init failed: Nested stability number of random "
+                "trial vectors parameter wrong.\n");
+        ok = false;
+    }
+    if (ss.n_iter != stability_defaults.n_iter) {
+        fprintf(stderr,
+                "test_solver_settings_init failed: Nested stability number of "
+                "parameter wrong.\n");
+        ok = false;
+    }
+    if (ss.jacobi_davidson_start != stability_defaults.jacobi_davidson_start) {
+        fprintf(stderr,
+                "test_solver_settings_init failed: Nested stability "
+                "Jacobi-Davidson starting parameter wrong.\n");
+        ok = false;
+    }
+    if (ss.seed != stability_defaults.seed) {
+        fprintf(stderr,
+                "test_solver_settings_init failed: Nested stability seed parameter "
+                "wrong.\n");
+        ok = false;
+    }
+    if (ss.verbose != stability_defaults.verbose) {
+        fprintf(stderr,
+                "test_solver_settings_init failed: Nested stability verbosity "
+                "parameter wrong.\n");
+        ok = false;
+    }
+    if (strcmp(ss.diag_solver, stability_defaults.diag_solver) != 0) {
+        fprintf(stderr,
+                "test_solver_settings_init failed: Nested stability diagonal solver "
+                "parameter wrong.\n");
+        ok = false;
+    }
+    if (ss.precond || ss.project || ss.logger) {
+        fprintf(stderr,
+                "test_solver_settings_init failed: Nested stability callback pointers "
+                "should be NULL.\n");
+        ok = false;
+    }
+
     return ok;
 }
 

--- a/tests/opentrustregion_unit_tests.f90
+++ b/tests/opentrustregion_unit_tests.f90
@@ -342,20 +342,11 @@ contains
         ! allocate space for the final gradient
         allocate(final_grad(n_param))
 
-        ! set a custom logger only on the nested stability check settings and check
-        ! that the internal stability check does not replace it
-        settings%stability_settings%logger => logger
-
         ! run solver, check if error has occured and check whether gradient is zero and 
         ! agrees with correct minimum
         call solver(update_orbs_funptr, obj_func_funptr, n_param, error, settings)
         if (error /= 0) then
             write (stderr, *) "test_solver failed: Produced error."
-            test_solver = .false.
-        end if
-        if (.not. associated(settings%stability_settings%logger, logger)) then
-            write (stderr, *) "test_solver failed: Custom logger set on nested "// &
-                "stability check settings was overwritten."
             test_solver = .false.
         end if
         call hartmann6d_gradient(curr_vars, final_grad)
@@ -400,11 +391,21 @@ contains
         update_orbs_funptr => update_orbs
         obj_func_funptr => obj_func
 
+        ! set a custom logger only on the nested stability check settings and check
+        ! that the internal stability check does not replace it, since starting
+        ! exactly at a stationary point always triggers it on the first iteration
+        settings%stability_settings%logger => logger
+
         ! run solver, check if error has occured and check whether gradient is zero and
         ! agrees with correct minimum
         call solver(update_orbs_funptr, obj_func_funptr, n_param, error, settings)
         if (error /= 0) then
             write (stderr, *) "test_solver failed: Produced error."
+            test_solver = .false.
+        end if
+        if (.not. associated(settings%stability_settings%logger, logger)) then
+            write (stderr, *) "test_solver failed: Custom logger set on nested "// &
+                "stability check settings was overwritten."
             test_solver = .false.
         end if
         call hartmann6d_gradient(curr_vars, final_grad)

--- a/tests/opentrustregion_unit_tests.f90
+++ b/tests/opentrustregion_unit_tests.f90
@@ -342,11 +342,20 @@ contains
         ! allocate space for the final gradient
         allocate(final_grad(n_param))
 
+        ! set a custom logger only on the nested stability check settings and check
+        ! that the internal stability check does not replace it
+        settings%stability_settings%logger => logger
+
         ! run solver, check if error has occured and check whether gradient is zero and 
         ! agrees with correct minimum
         call solver(update_orbs_funptr, obj_func_funptr, n_param, error, settings)
         if (error /= 0) then
             write (stderr, *) "test_solver failed: Produced error."
+            test_solver = .false.
+        end if
+        if (.not. associated(settings%stability_settings%logger, logger)) then
+            write (stderr, *) "test_solver failed: Custom logger set on nested "// &
+                "stability check settings was overwritten."
             test_solver = .false.
         end if
         call hartmann6d_gradient(curr_vars, final_grad)
@@ -391,7 +400,7 @@ contains
         update_orbs_funptr => update_orbs
         obj_func_funptr => obj_func
 
-        ! run solver, check if error has occured and check whether gradient is zero and 
+        ! run solver, check if error has occured and check whether gradient is zero and
         ! agrees with correct minimum
         call solver(update_orbs_funptr, obj_func_funptr, n_param, error, settings)
         if (error /= 0) then

--- a/tests/opentrustregion_unit_tests.f90
+++ b/tests/opentrustregion_unit_tests.f90
@@ -396,6 +396,10 @@ contains
         ! exactly at a stationary point always triggers it on the first iteration
         settings%stability_settings%logger => logger
 
+        ! raise the solver verbosity above the nested stability check settings'
+        ! default verbosity and check that it gets propagated to the nested settings
+        settings%verbose = 2_ip
+
         ! run solver, check if error has occured and check whether gradient is zero and
         ! agrees with correct minimum
         call solver(update_orbs_funptr, obj_func_funptr, n_param, error, settings)
@@ -406,6 +410,11 @@ contains
         if (.not. associated(settings%stability_settings%logger, logger)) then
             write (stderr, *) "test_solver failed: Custom logger set on nested "// &
                 "stability check settings was overwritten."
+            test_solver = .false.
+        end if
+        if (settings%stability_settings%verbose < settings%verbose) then
+            write (stderr, *) "test_solver failed: Solver verbosity was not "// &
+                "propagated to nested stability check settings."
             test_solver = .false.
         end if
         call hartmann6d_gradient(curr_vars, final_grad)

--- a/tests/test_reference.f90
+++ b/tests/test_reference.f90
@@ -735,6 +735,9 @@ contains
         lhs%verbose = rhs%verbose
         lhs%subsystem_solver = rhs%subsystem_solver
 
+        ! set nested stability check settings
+        lhs%stability_settings = rhs
+
         ! set initialization logical
         lhs%initialized = .true.
 
@@ -853,7 +856,8 @@ contains
             lhs%n_macro == rhs%n_macro .and. lhs%n_micro == rhs%n_micro .and. &
             lhs%jacobi_davidson_start == rhs%jacobi_davidson_start .and. &
             lhs%seed == rhs%seed .and. lhs%verbose == rhs%verbose .and. &
-            lhs%subsystem_solver == rhs%subsystem_solver
+            lhs%subsystem_solver == rhs%subsystem_solver .and. &
+            lhs%stability_settings == rhs
 
     end function equal_solver_to_ref
 
@@ -988,7 +992,8 @@ contains
             lhs%n_macro == rhs%n_macro .and. lhs%n_micro == rhs%n_micro .and. &
             lhs%jacobi_davidson_start == rhs%jacobi_davidson_start .and. &
             lhs%seed == rhs%seed .and. lhs%verbose == rhs%verbose .and. &
-            lhs%subsystem_solver == rhs%subsystem_solver
+            lhs%subsystem_solver == rhs%subsystem_solver .and. &
+            lhs%stability_settings == rhs%stability_settings
 
     end function equal_solver
 


### PR DESCRIPTION
`solver_settings_type` gains a `stability_settings` component (a full `stability_settings_type`). Previously the solver's automatic post-convergence/first-iteration stability check built a throwaway local settings object and copied over only `precond` and `logger` from the top-level solver settings. Every other stability check setting was unreachable from the solver's public interface. Now the nested object is user-settable directly (`settings%stability_settings%conv_tol = ...` / `settings.stability_settings.conv_tol = ...` in Python) and is used as-is by the internal call. `precond`, `project`, and `logger` still fall back to the solver's own callbacks when left unset on the nested object, so existing callers see no behavior change by default.