### PR TITLE
Fix Codecov coverage reporting and guard test helpers against unassociated function pointers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - main
+      - 'ci-debug/**'
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   formatting:
@@ -13,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout OpenTrustRegion
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: 3.x
 
@@ -138,10 +140,10 @@ jobs:
 
     steps:
     - name: Checkout OpenTrustRegion
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: 3.x
 
@@ -272,7 +274,7 @@ jobs:
 
     - name: Install Coverage Tools
       if: ${{ matrix.build-type == 'coverage' }}
-      run: pip install gcovr coverage
+      run: pip install coverage
 
     - name: Build & Install OpenTrustRegion with Coverage Flags
       if: ${{ matrix.build-type == 'coverage' }}
@@ -284,17 +286,39 @@ jobs:
       run: coverage run --omit="pyopentrustregion/testsuite.py" -m pyopentrustregion.testsuite
 
     - name: Generate Coverage Report
+      id: coverage
       if: ${{ matrix.build-type == 'coverage' }}
       run: |
+        set -e
         coverage xml -o python_coverage.xml
-        gcovr -r . --exclude 'build/.*' --exclude 'tests/.*' --xml -o fortran_coverage.xml
+        gcda=$(find build/CMakeFiles/opentrustregion.dir -name '*.gcda')
+        gcov -b $gcda
+        files=./python_coverage.xml
+        for g in $gcda; do
+          f=$(basename "$g" .gcda).gcov
+          if [ ! -s "$f" ]; then
+            echo "::error::gcov did not produce $f"
+            exit 1
+          fi
+          files="$files,./$f"
+        done
+        echo "files=$files" >> "$GITHUB_OUTPUT"
+
+    - name: Upload Coverage Reports as Artifacts
+      if: ${{ matrix.build-type == 'coverage' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: coverage-reports
+        path: |
+          python_coverage.xml
+          *.gcov
 
     - name: Upload to Codecov
       if: ${{ matrix.build-type == 'coverage' }}
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       with:
-        file: |
-          fortran_coverage.xml
-          python_coverage.xml
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        files: ${{ steps.coverage.outputs.files }}
+        disable_search: true
+        plugins: noop
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true

--- a/tests/c_interface_unit_tests.f90
+++ b/tests/c_interface_unit_tests.f90
@@ -237,7 +237,8 @@ contains
                                           settings, kappa_c_ptr)
 
         ! check if test has passed
-        test_stability_check_c_wrapper = test_passed
+        test_stability_check_c_wrapper = test_stability_check_c_wrapper .and. &
+                                         test_passed
 
         ! check if logging subroutine was correctly called
         if (.not. test_logger) then

--- a/tests/opentrustregion_unit_tests.f90
+++ b/tests/opentrustregion_unit_tests.f90
@@ -879,7 +879,7 @@ contains
 
         type(solver_settings_type) :: settings
         procedure(obj_func_type), pointer :: obj_func_funptr
-        real(rp) :: vars(6), lower, upper, n
+        real(rp) :: vars(n_param), lower, upper, n
         integer(ip) :: error
 
         ! assume tests pass
@@ -1692,7 +1692,7 @@ contains
 
         type(solver_settings_type) :: settings
         procedure(hess_x_type), pointer :: hess_x_funptr
-        real(rp), dimension(6) :: vars, vector, solution, corr_vector, hess_vector
+        real(rp), dimension(n_param) :: vars, vector, solution, corr_vector, hess_vector
         integer(ip) :: error
 
         ! assume tests pass
@@ -1745,7 +1745,8 @@ contains
 
         type(solver_settings_type) :: settings
         procedure(hess_x_type), pointer :: hess_x_funptr
-        real(rp), dimension(6) :: vars, rhs, solution, vector, hess_vector, corr_vector
+        real(rp), dimension(n_param) :: vars, rhs, solution, vector, hess_vector, &
+                                        corr_vector
         real(rp) :: mu
         real(rp), parameter :: rtol = 1e-14_rp
         integer(ip) :: error
@@ -2620,7 +2621,7 @@ contains
         ! assume tests pass
         test_string_to_lowercase = .true.
 
-        ! test transfoer to lowercase
+        ! test transfer to lowercase
         if (string_to_lowercase(input) /= expect) then
             write (stderr, *) "test_string_to_lowercase failed: String not "// &
                 "correctly transferred to lowercase."

--- a/tests/test_reference.f90
+++ b/tests/test_reference.f90
@@ -8,7 +8,8 @@ module test_reference
 
     use opentrustregion, only: rp, ip, kw_len, stderr
     use c_interface, only: c_rp, c_ip
-    use, intrinsic :: iso_c_binding, only: c_bool, c_char, c_funptr, c_f_procpointer
+    use, intrinsic :: iso_c_binding, only: c_bool, c_char, c_funptr, c_f_procpointer, &
+                                           c_associated
 
     implicit none
 
@@ -98,6 +99,14 @@ contains
         ! assume tests pass
         test_passed = .true.
 
+        ! check if function pointer is associated
+        if (.not. associated(update_orbs_funptr)) then
+            test_passed = .false.
+            write (stderr, *) "test_"//test_name//" failed: Orbital updating "// &
+                "function not associated with value."
+            return
+        end if
+
         ! allocate arrays
         allocate(kappa(n_param), grad(n_param), h_diag(n_param))
 
@@ -165,6 +174,14 @@ contains
         ! assume tests pass
         test_passed = .true.
 
+        ! check if function pointer is associated
+        if (.not. c_associated(update_orbs_c_funptr)) then
+            test_passed = .false.
+            write (stderr, *) "test_"//test_name//" failed: Orbital updating "// &
+                "function not associated with value."
+            return
+        end if
+
         ! convert to Fortran function pointer
         call c_f_procpointer(cptr=update_orbs_c_funptr, fptr=update_orbs_funptr)
 
@@ -231,6 +248,14 @@ contains
         ! assume tests pass
         test_passed = .true.
 
+        ! check if function pointer is associated
+        if (.not. associated(hess_x_funptr)) then
+            test_passed = .false.
+            write (stderr, *) "test_"//test_name//" failed: Hessian linear "// &
+                "transformation function not associated with value."
+            return
+        end if
+
         ! allocate arrays
         allocate(x(n_param), hess_x(n_param))
 
@@ -277,6 +302,14 @@ contains
 
         ! assume tests pass
         test_passed = .true.
+
+        ! check if function pointer is associated
+        if (.not. c_associated(hess_x_c_funptr)) then
+            test_passed = .false.
+            write (stderr, *) "test_"//test_name//" failed: Hessian linear "// &
+                "transformation function not associated with value."
+            return
+        end if
 
         ! convert to Fortran function pointer
         call c_f_procpointer(cptr=hess_x_c_funptr, fptr=hess_x_funptr_c)
@@ -327,6 +360,14 @@ contains
         ! assume tests pass
         test_passed = .true.
 
+        ! check if function pointer is associated
+        if (.not. associated(obj_func_funptr)) then
+            test_passed = .false.
+            write (stderr, *) "test_"//test_name//" failed: Objective function not "// &
+                "associated with value."
+            return
+        end if
+
         ! allocate arrays
         allocate(kappa(n_param))
 
@@ -373,6 +414,14 @@ contains
 
         ! assume tests pass
         test_passed = .true.
+
+        ! check if function pointer is associated
+        if (.not. c_associated(obj_func_c_funptr)) then
+            test_passed = .false.
+            write (stderr, *) "test_"//test_name//" failed: Objective function not "// &
+                "associated with value."
+            return
+        end if
 
         ! convert to Fortran function pointer
         call c_f_procpointer(cptr=obj_func_c_funptr, fptr=obj_func_funptr)
@@ -422,6 +471,14 @@ contains
         ! assume tests pass
         test_passed = .true.
 
+        ! check if function pointer is associated
+        if (.not. associated(precond_funptr)) then
+            test_passed = .false.
+            write (stderr, *) "test_"//test_name//" failed: Preconditioner "// &
+                "function not associated with value."
+            return
+        end if
+
         ! allocate arrays
         allocate(residual(n_param), precond_residual(n_param))
 
@@ -467,6 +524,14 @@ contains
 
         ! assume tests pass
         test_passed = .true.
+
+        ! check if function pointer is associated
+        if (.not. c_associated(precond_c_funptr)) then
+            test_passed = .false.
+            write (stderr, *) "test_"//test_name//" failed: Preconditioner "// &
+                "function not associated with value."
+            return
+        end if
 
         ! convert to Fortran function pointer
         call c_f_procpointer(cptr=precond_c_funptr, fptr=precond_funptr)
@@ -515,6 +580,14 @@ contains
         ! assume tests pass
         test_passed = .true.
 
+        ! check if function pointer is associated
+        if (.not. associated(project_funptr)) then
+            test_passed = .false.
+            write (stderr, *) "test_"//test_name//" failed: Project function "// &
+                "not associated with value."
+            return
+        end if
+
         ! allocate arrays
         allocate(vector(n_param))
 
@@ -560,6 +633,14 @@ contains
 
         ! assume tests pass
         test_passed = .true.
+
+        ! check if function pointer is associated
+        if (.not. c_associated(project_c_funptr)) then
+            test_passed = .false.
+            write (stderr, *) "test_"//test_name//" failed: Project function "// &
+                "not associated with value."
+            return
+        end if
 
         ! convert to Fortran function pointer
         call c_f_procpointer(cptr=project_c_funptr, fptr=project_funptr)
@@ -609,6 +690,14 @@ contains
         ! assume tests pass
         test_passed = .true.
 
+        ! check if function pointer is associated
+        if (.not. associated(conv_check_funptr)) then
+            test_passed = .false.
+            write (stderr, *) "test_"//test_name//" failed: Convergence check "// &
+                "function not associated with value."
+            return
+        end if
+
         ! call convergence check function
         converged = conv_check_funptr(error)
 
@@ -645,6 +734,14 @@ contains
 
         ! assume tests pass
         test_passed = .true.
+
+        ! check if function pointer is associated
+        if (.not. c_associated(conv_check_c_funptr)) then
+            test_passed = .false.
+            write (stderr, *) "test_"//test_name//" failed: Convergence check "// &
+                "function not associated with value."
+            return
+        end if
 
         ! convert to Fortran function pointer
         call c_f_procpointer(cptr=conv_check_c_funptr, fptr=conv_check_funptr)

--- a/tests/test_reference.f90
+++ b/tests/test_reference.f90
@@ -103,7 +103,7 @@ contains
         if (.not. associated(update_orbs_funptr)) then
             test_passed = .false.
             write (stderr, *) "test_"//test_name//" failed: Orbital updating "// &
-                "function not associated with value."
+                "function provided"//message//" not associated with value."
             return
         end if
 
@@ -147,10 +147,13 @@ contains
         ! deallocate arrays
         deallocate(kappa, grad, h_diag)
 
-        ! test returned Hessian linear transformation
-        test_passed = test_passed .and. &
-            test_hess_x_funptr(hess_x_funptr, test_name, " by Hessian linear "// &
-                               "transformation function returned"//message)
+        ! test returned Hessian linear transformation, the function pointer is only
+        ! defined if the orbital update did not produce an error
+        if (error == 0) then
+            test_passed = test_passed .and. &
+                test_hess_x_funptr(hess_x_funptr, test_name, " by Hessian linear "// &
+                                   "transformation function returned"//message)
+        end if
 
     end function test_update_orbs_funptr
 
@@ -178,7 +181,7 @@ contains
         if (.not. c_associated(update_orbs_c_funptr)) then
             test_passed = .false.
             write (stderr, *) "test_"//test_name//" failed: Orbital updating "// &
-                "function not associated with value."
+                "function provided"//message//" not associated with value."
             return
         end if
 
@@ -225,10 +228,14 @@ contains
         ! deallocate arrays
         deallocate(kappa, grad, h_diag)
 
-        ! test returned Hessian linear transformation
-        test_passed = test_passed .and. &
-            test_hess_x_c_funptr(hess_x_c_funptr, test_name, " by Hessian linear "// &
-                                 "transformation function returned"//message)
+        ! test returned Hessian linear transformation, the function pointer is only
+        ! defined if the orbital update did not produce an error
+        if (error == 0) then
+            test_passed = test_passed .and. &
+                test_hess_x_c_funptr(hess_x_c_funptr, test_name, " by Hessian "// &
+                                     "linear transformation function returned"// &
+                                     message)
+        end if
 
     end function test_update_orbs_c_funptr
 
@@ -252,7 +259,8 @@ contains
         if (.not. associated(hess_x_funptr)) then
             test_passed = .false.
             write (stderr, *) "test_"//test_name//" failed: Hessian linear "// &
-                "transformation function not associated with value."
+                "transformation function provided"//message//" not associated "// &
+                "with value."
             return
         end if
 
@@ -307,7 +315,8 @@ contains
         if (.not. c_associated(hess_x_c_funptr)) then
             test_passed = .false.
             write (stderr, *) "test_"//test_name//" failed: Hessian linear "// &
-                "transformation function not associated with value."
+                "transformation function provided"//message//" not associated "// &
+                "with value."
             return
         end if
 
@@ -363,8 +372,8 @@ contains
         ! check if function pointer is associated
         if (.not. associated(obj_func_funptr)) then
             test_passed = .false.
-            write (stderr, *) "test_"//test_name//" failed: Objective function not "// &
-                "associated with value."
+            write (stderr, *) "test_"//test_name//" failed: Objective function "// &
+                "provided"//message//" not associated with value."
             return
         end if
 
@@ -418,8 +427,8 @@ contains
         ! check if function pointer is associated
         if (.not. c_associated(obj_func_c_funptr)) then
             test_passed = .false.
-            write (stderr, *) "test_"//test_name//" failed: Objective function not "// &
-                "associated with value."
+            write (stderr, *) "test_"//test_name//" failed: Objective function "// &
+                "provided"//message//" not associated with value."
             return
         end if
 
@@ -475,7 +484,7 @@ contains
         if (.not. associated(precond_funptr)) then
             test_passed = .false.
             write (stderr, *) "test_"//test_name//" failed: Preconditioner "// &
-                "function not associated with value."
+                "function provided"//message//" not associated with value."
             return
         end if
 
@@ -529,7 +538,7 @@ contains
         if (.not. c_associated(precond_c_funptr)) then
             test_passed = .false.
             write (stderr, *) "test_"//test_name//" failed: Preconditioner "// &
-                "function not associated with value."
+                "function provided"//message//" not associated with value."
             return
         end if
 
@@ -584,7 +593,7 @@ contains
         if (.not. associated(project_funptr)) then
             test_passed = .false.
             write (stderr, *) "test_"//test_name//" failed: Project function "// &
-                "not associated with value."
+                "provided"//message//" not associated with value."
             return
         end if
 
@@ -638,7 +647,7 @@ contains
         if (.not. c_associated(project_c_funptr)) then
             test_passed = .false.
             write (stderr, *) "test_"//test_name//" failed: Project function "// &
-                "not associated with value."
+                "provided"//message//" not associated with value."
             return
         end if
 
@@ -694,7 +703,7 @@ contains
         if (.not. associated(conv_check_funptr)) then
             test_passed = .false.
             write (stderr, *) "test_"//test_name//" failed: Convergence check "// &
-                "function not associated with value."
+                "function provided"//message//" not associated with value."
             return
         end if
 
@@ -739,7 +748,7 @@ contains
         if (.not. c_associated(conv_check_c_funptr)) then
             test_passed = .false.
             write (stderr, *) "test_"//test_name//" failed: Convergence check "// &
-                "function not associated with value."
+                "function provided"//message//" not associated with value."
             return
         end if
 


### PR DESCRIPTION
Codecov had not recorded a `main`-branch commit since 2026-05-11: uploads were rejected for lack of a token, the `file:` input was malformed, and the `gcovr` invocation produced an empty report — each fault masking the next while CI stayed green. Fortran coverage is now generated with `gcov` instead of `gcovr`, the upload is pinned to explicit files with `fail_ci_if_error: true`, and the actions are bumped off deprecated Node 20. Reported coverage shifts slightly as a result, and is now correct.

The `ref_*` callback helpers in `test_reference.f90` now check their function pointer is associated before invoking it, failing with a clear message instead of crashing. Plus a hardcoded dimension replaced with `n_param` and a typo fix.